### PR TITLE
fix: seed reference data in all environments

### DIFF
--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -43,7 +43,13 @@ if (process.env.NODE_ENV !== 'production') {
 
 // Re-export Prisma types for use in other packages
 export * from '@prisma/client';
-// Re-export seed utilities for auto-seeding in dev
-export { isDatabaseEmpty, seedDatabase, seedIfEmpty } from './seed/seedDatabase.js';
+// Re-export seed utilities
+export {
+  isDatabaseEmpty,
+  seedDatabase,
+  seedIfEmpty,
+  seedReferenceData,
+  seedTestData,
+} from './seed/seedDatabase.js';
 // Re-export application-level type definitions
 export * from './types.js';


### PR DESCRIPTION
## Summary
- Split `seedDatabase` into `seedReferenceData` (quota presets + scenarios) and `seedTestData` (test admin + invitation)
- Reference data now seeds in all environments including production
- Test data only seeds in development

Fixes production deploy not having quota presets or scenarios available.

## Test plan
- [ ] Verify dev server still auto-seeds both reference and test data
- [ ] Verify production build only seeds reference data

🤖 Generated with [Claude Code](https://claude.com/claude-code)