### PR TITLE
fix: correct SESSION_KEY requirements in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,8 @@ NODE_ENV=development
 # Frontend
 FRONTEND_URL=http://localhost:5173
 
-# Session encryption key (at least 32 characters)
+# Session encryption key (must be exactly 64 hex characters = 32 bytes)
 # Generate with: openssl rand -hex 32
-# Or just make up a random string of 32+ letters/numbers (e.g., mash your keyboard)
 SESSION_KEY=
 
 # Google OAuth (get from https://console.cloud.google.com/)


### PR DESCRIPTION
## Summary
- Fixed misleading comment that said "at least 32 characters"
- Now correctly states "must be exactly 64 hex characters = 32 bytes"
- Removed incorrect suggestion to "mash your keyboard" (won't produce valid hex)

## Test plan
- [ ] Verify comment is accurate by checking `packages/api/src/plugins/session.ts` uses `Buffer.from(sessionKey, 'hex')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)