### PR TITLE
Implement mobile slide-up coach aside split-screen

### DIFF
--- a/packages/app/src/components/conversation/AsidePanel.tsx
+++ b/packages/app/src/components/conversation/AsidePanel.tsx
@@ -118,15 +118,19 @@ export function AsidePanel({
 
       {/* Panel */}
       <div
-        className={`fixed top-0 right-0 h-full bg-white shadow-xl transform transition-transform duration-200 ease-out flex flex-col z-50 ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
-        } w-[calc(100%-3rem)] md:w-[400px]`}
+        className={`fixed z-50 bg-white shadow-xl flex flex-col transform transition-transform duration-300 ease-out
+          bottom-0 left-0 w-full h-[85vh] rounded-t-2xl md:rounded-none
+          md:top-0 md:right-0 md:h-full md:w-[400px] md:bottom-auto md:left-auto
+          ${isOpen
+            ? 'translate-y-0 md:translate-x-0'
+            : 'translate-y-full md:translate-x-full md:translate-y-0'
+          }`}
         role="dialog"
         aria-label="Ask Coach"
         aria-hidden={!isOpen}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b bg-amber-50">
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-amber-50 rounded-t-2xl md:rounded-none">
           <h2 className="text-lg font-semibold text-amber-900">Ask Coach</h2>
           <button
             type="button"
@@ -143,7 +147,8 @@ export function AsidePanel({
               className="h-6 w-6"
               aria-hidden="true"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" className="md:hidden" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" className="hidden md:block" />
             </svg>
           </button>
         </div>

--- a/packages/app/src/pages/Conversation.tsx
+++ b/packages/app/src/pages/Conversation.tsx
@@ -203,13 +203,33 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
             disabled={isStreaming || quota?.exhausted || false}
             placeholder={quota?.exhausted ? 'Quota exhausted' : undefined}
           />
-          {/* Ask Coach button positioned above the input */}
-          <div className="absolute right-4 -top-12">
+          {/* Ask Coach button positioned above the input (Desktop) */}
+          <div className="absolute right-4 -top-12 hidden md:block">
             <AsideButton
               onClick={handleAsideOpen}
               disabled={isStreaming || quota?.exhausted || false}
             />
           </div>
+
+          {/* Mobile Ask Coach Slide-up Trigger */}
+          <button
+            type="button"
+            onClick={handleAsideOpen}
+            disabled={isStreaming || quota?.exhausted || false}
+            className="absolute left-1/2 -top-10 -translate-x-1/2 flex items-center justify-center h-8 w-12 rounded-t-lg bg-amber-500 text-white shadow-lg md:hidden hover:bg-amber-600 disabled:bg-gray-300"
+            aria-label="Ask Coach"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2.5}
+              stroke="currentColor"
+              className="h-5 w-5"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+            </svg>
+          </button>
         </div>
       </div>
 
@@ -225,13 +245,12 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
             </div>
             <div className="mt-1 h-1.5 w-full rounded-full bg-gray-200">
               <div
-                className={`h-1.5 rounded-full transition-all ${
-                  quota.exhausted
+                className={`h-1.5 rounded-full transition-all ${quota.exhausted
                     ? 'bg-red-500'
                     : quota.remaining < quota.total * 0.2
                       ? 'bg-amber-500'
                       : 'bg-blue-500'
-                }`}
+                  }`}
                 style={{
                   width: `${Math.min(100, ((quota.total - quota.remaining) / quota.total) * 100)}%`,
                 }}


### PR DESCRIPTION
(named the branch incorrectly, sorry about that!)
Mobile users can now access coach conversations through a new slide-up drawer, while desktop users have this side split screen option on the side rather than on the bottom. In the next version, I'll add functionality to swipe this box up and down manually to make it look cleaner, if needed.

On mobile:
<img width="526" height="783" alt="Screenshot 2026-01-27 at 5 29 26 PM" src="https://github.com/user-attachments/assets/3ded41e0-88d8-405d-ae41-447366c9826d" />
