### PR TITLE
fix: handle Windows line endings in Docker entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF for all text files
+* text=auto eol=lf
+
+# Explicitly mark shell scripts
+*.sh text eol=lf

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -19,9 +19,9 @@ COPY QUICKSTART.md ./
 # Install dependencies (workspace packages will be properly linked)
 RUN pnpm install --frozen-lockfile
 
-# Copy entrypoint script
+# Copy entrypoint script (strip Windows line endings if present)
 COPY packages/api/docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to enforce LF line endings repo-wide
- Strip carriage returns during Docker build so the entrypoint script works regardless of the developer's OS or Git config

## Test plan
- [ ] Teammate on Windows rebuilds API container and confirms it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)