### PR TITLE
feat: unified chat, keyboard-replacement coach panel, and visual polish

### DIFF
--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -482,8 +482,8 @@ export class ConversationManager {
         context: LLMMessage[]
     ): Promise<{ content: string; messageId: number; usage: TokenUsage } | null> {
         const scenario = this.session.scenario;
-        let modelString = scenario?.coachModel ?? DEFAULT_MODEL;
-        let systemPrompt = (scenario?.coachSystemPrompt ?? this.session.customCoachPrompt ?? '') + ASIDE_INSTRUCTIONS;
+        const modelString = scenario?.coachModel ?? DEFAULT_MODEL;
+        const systemPrompt = (scenario?.coachSystemPrompt ?? this.session.customCoachPrompt ?? '') + ASIDE_INSTRUCTIONS;
 
         let fullContent = '';
         let usage: TokenUsage = { inputTokens: 0, outputTokens: 0 };
@@ -503,6 +503,7 @@ export class ConversationManager {
                     usage = chunk.usage;
                 }
             }
+
             const message = await this.persistMessage('coach', fullContent, {
                 messageType: 'aside',
                 asideThreadId: threadId,
@@ -510,7 +511,7 @@ export class ConversationManager {
             this.session.messages.push(message);
             send(this.ws, { type: 'aside:done', threadId, messageId: message.id, usage });
             return { content: fullContent, messageId: message.id, usage };
-        } catch (error) {
+        } catch (_error) {
             return null;
         }
     }

--- a/packages/api/src/ws/handler.ts
+++ b/packages/api/src/ws/handler.ts
@@ -83,6 +83,7 @@ export async function registerWebSocketHandler(fastify: FastifyInstance): Promis
       const manager = new ConversationManager(
         socket,
         prisma,
+        // biome-ignore lint/suspicious/noExplicitAny: legacy code
         { ...session, scenario: session.scenario, userId: userId as string } as any,
         fastify.log
       );

--- a/packages/app/src/components/conversation/CoachInsightsPanel.tsx
+++ b/packages/app/src/components/conversation/CoachInsightsPanel.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react';
+import Markdown from 'react-markdown';
+import type { AsideMessage } from '../../hooks/useConversationSocket';
+
+interface CoachInsightsPanelProps {
+    isOpen: boolean;
+    onClose: () => void;
+    messages: AsideMessage[];
+}
+
+export function CoachInsightsPanel({ isOpen, onClose, messages }: CoachInsightsPanelProps) {
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    // Auto-scroll to bottom when messages change
+    // biome-ignore lint/correctness/useExhaustiveDependencies: need to scroll on messages change
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
+    }, [messages]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="flex flex-col border-t border-gray-200 bg-gray-50 md:hidden h-[40dvh]">
+            {/* 
+                Keyboard Replacement View:
+                - Fixed height (approx keyboard height, e.g. 40dvh)
+                - No header (clean keyboard look)
+                - Scrollable content
+             */}
+
+            {/* Content */}
+            <div
+                ref={scrollRef}
+                className="flex-1 overflow-y-auto p-4 space-y-4"
+            >
+                {messages.filter(m => m.role === 'coach').length === 0 ? (
+                    <div className="flex h-full items-center justify-center text-center text-sm text-gray-400">
+                        <p>No insights yet...</p>
+                    </div>
+                ) : (
+                    messages.filter(m => m.role === 'coach').map((msg) => (
+                        <InsightCard key={msg.id} message={msg} />
+                    ))
+                )}
+            </div>
+
+            {/* Optional: Small 'close' or 'hide' handle if needed, but blurring input typically handles it. 
+                 We can keep a small subtle indicator or close button if user gets stuck.
+             */}
+            <div className="flex justify-center pb-2 pt-1 border-t border-gray-100 bg-gray-50">
+                <button type="button" onClick={onClose} className="h-1 w-12 rounded-full bg-gray-300" aria-label="Close panel" />
+            </div>
+        </div>
+    );
+}
+
+
+function InsightCard({ message }: { message: AsideMessage }) {
+    if (message.role === 'user') {
+        return (
+            <div className="flex justify-end">
+                <div className="rounded-xl bg-gray-200 px-3 py-2 text-sm text-gray-800 max-w-[85%]">
+                    {message.content}
+                </div>
+            </div>
+        );
+    }
+
+    // Standard Card view (Green/Teal)
+    return (
+        <div className="rounded-xl border border-teal-100 bg-teal-50 p-3 shadow-sm">
+            <div className="flex gap-3">
+                <div className="mt-0.5 shrink-0 text-teal-800">
+                    {/* Lightbulb Icon */}
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5" aria-hidden="true">
+                        <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+                        <path d="M9 18h6" />
+                        <path d="M10 22h4" />
+                    </svg>
+                </div>
+                <div className="text-sm text-gray-800 flex-1 [&_p]:mb-1 [&_p:last-child]:mb-0 [&_p]:leading-snug [&_strong]:font-bold [&_strong]:text-teal-900">
+                    <Markdown>{message.content}</Markdown>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/packages/app/src/components/conversation/MessageBubble.tsx
+++ b/packages/app/src/components/conversation/MessageBubble.tsx
@@ -27,7 +27,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   if (role === 'user') {
     return (
       <div className="flex justify-end">
-        <div className={`${baseClasses} bg-blue-600 text-white ${markdownClasses}`}>
+        <div className={`${baseClasses} bg-gray-200 text-gray-900 ${markdownClasses}`}>
           <Markdown>{content}</Markdown>
         </div>
       </div>
@@ -37,7 +37,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   if (role === 'partner') {
     return (
       <div className="flex justify-start">
-        <div className={`${baseClasses} bg-gray-200 text-gray-900 ${markdownClasses}`}>
+        <div className={`${baseClasses} bg-white text-gray-900 border border-gray-200 shadow-sm ${markdownClasses}`}>
           <Markdown>{content}</Markdown>
           {isStreaming && <span className="ml-1 animate-pulse">|</span>}
         </div>
@@ -46,12 +46,13 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   }
 
   // Coach message - centered with distinct styling
+  // User requested "Yellow" if uncle is white.
   return (
     <div className="flex justify-center">
       <div
-        className={`${baseClasses} bg-amber-100 text-amber-900 border border-amber-200 text-sm ${markdownClasses}`}
+        className={`${baseClasses} bg-yellow-100 text-yellow-900 border border-yellow-200 text-sm ${markdownClasses}`}
       >
-        <span className="font-semibold">Coach:</span>
+        <span className="font-semibold block mb-1">Coach:</span>
         <Markdown>{content}</Markdown>
         {isStreaming && <span className="ml-1 animate-pulse">|</span>}
       </div>

--- a/packages/app/src/components/conversation/MobileMessageInput.tsx
+++ b/packages/app/src/components/conversation/MobileMessageInput.tsx
@@ -1,0 +1,186 @@
+import { type FormEvent, type KeyboardEvent, useEffect, useRef, useState } from 'react';
+
+interface MobileMessageInputProps {
+    onSendPartner: (content: string) => void;
+    onSendCoach: (content: string) => void;
+    partnerName: string;
+    disabled: boolean;
+    isInsightsOpen: boolean;
+    onToggleInsights: () => void;
+    onInputFocus?: () => void;
+    onInputBlur?: () => void;
+}
+
+type Recipient = 'partner' | 'coach';
+
+export function MobileMessageInput({
+    onSendPartner,
+    onSendCoach,
+    partnerName,
+    disabled,
+    isInsightsOpen,
+    onToggleInsights,
+    onInputFocus,
+    onInputBlur,
+}: MobileMessageInputProps) {
+    const [content, setContent] = useState('');
+    const [recipient, setRecipient] = useState<Recipient>('partner');
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsDropdownOpen(false);
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    const handleSubmit = (e: FormEvent) => {
+        e.preventDefault();
+        if (content.trim() && !disabled) {
+            if (recipient === 'partner') {
+                onSendPartner(content.trim());
+            } else {
+                onSendCoach(content.trim());
+            }
+            setContent('');
+        }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSubmit(e);
+        }
+    };
+
+    const handleRecipientSelect = (newRecipient: Recipient) => {
+        setRecipient(newRecipient);
+        setIsDropdownOpen(false);
+    };
+
+    return (
+        <div className="border-t bg-white p-2">
+            {/* Input Row */}
+            <form onSubmit={handleSubmit} className="flex gap-2">
+                <div className="relative" ref={dropdownRef}>
+
+                    <button
+                        type="button"
+                        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                        className={`flex h-10 w-12 items-center justify-center rounded-xl bg-gray-50 text-gray-900 border border-gray-200 ${isDropdownOpen ? 'bg-gray-100' : ''}`}
+                        aria-label="Switch partner"
+                    >
+                        {activeIcon(recipient)}
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 ml-0.5 opacity-60" aria-hidden="true">
+                            <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+                        </svg>
+                    </button>
+
+                    {/* Dropdown Menu Positioned bottom-up or just above */}
+                    {isDropdownOpen && (
+                        <div className="absolute bottom-12 left-0 w-64 rounded-2xl border border-gray-100 bg-white p-2 shadow-xl ring-1 ring-black/5 z-20">
+                            <button
+                                type="button"
+                                onClick={() => handleRecipientSelect('partner')}
+                                className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors ${recipient === 'partner' ? 'bg-gray-50' : 'hover:bg-gray-50'
+                                    }`}
+                            >
+                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+                                        <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.957 9.957 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 0 0-13.074.003Z" />
+                                    </svg>
+                                </div>
+                                <div>
+                                    <div className="font-semibold text-gray-900">{partnerName}</div>
+                                    <div className="text-xs text-gray-500">Practice conversation</div>
+                                </div>
+                            </button>
+
+                            <button
+                                type="button"
+                                onClick={() => handleRecipientSelect('coach')}
+                                className={`mt-1 flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors ${recipient === 'coach' ? 'bg-gray-50' : 'hover:bg-gray-50'
+                                    }`}
+                            >
+                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" aria-hidden="true">
+                                        <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+                                        <path d="M9 18h6" />
+                                        <path d="M10 22h4" />
+                                    </svg>
+                                </div>
+                                <div>
+                                    <div className="font-semibold text-gray-900">Conversation Coach</div>
+                                    <div className="text-xs text-gray-500">Ask for advice</div>
+                                </div>
+                            </button>
+                        </div>
+                    )}
+                </div>
+
+                <textarea
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    onFocus={onInputFocus}
+                    onBlur={onInputBlur}
+                    placeholder={recipient === 'partner' ? `Reply to ${partnerName}...` : "Ask the coach..."}
+                    disabled={disabled}
+                    rows={1}
+                    className="flex-1 resize-none rounded-xl border border-gray-200 px-4 py-2.5 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-100 disabled:text-gray-500"
+                />
+
+                {/* Insights Toggle */}
+                <button
+                    type="button"
+                    onClick={onToggleInsights}
+                    className={`flex h-10 w-10 items-center justify-center rounded-xl border transition-colors ${isInsightsOpen
+                        ? 'bg-teal-100 text-teal-700 border-teal-200'
+                        : 'bg-white text-gray-500 border-gray-200 hover:bg-gray-50'
+                        }`}
+                    aria-label="Toggle insights"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" aria-hidden="true">
+                        <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+                        <path d="M9 18h6" />
+                        <path d="M10 22h4" />
+                    </svg>
+                </button>
+
+                <button
+                    type="submit"
+                    disabled={disabled || !content.trim()}
+                    className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-50 text-gray-400 hover:text-teal-600 disabled:opacity-50"
+                    aria-label="Send message"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5 -rotate-45 translate-x-0.5 -translate-y-0.5" aria-hidden="true">
+                        <path d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z" />
+                    </svg>
+                </button>
+            </form>
+        </div>
+    );
+}
+
+function activeIcon(recipient: Recipient) {
+    if (recipient === 'partner') {
+        return (
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+                <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.957 9.957 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 0 0-13.074.003Z" />
+            </svg>
+        );
+    }
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" aria-hidden="true">
+            <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+            <path d="M9 18h6" />
+            <path d="M10 22h4" />
+        </svg>
+    )
+}
+


### PR DESCRIPTION
Implemented Vipula's design (https://scale-game-00240834.figma.site/) for conversation on mobile, where you can switch contexts between speaking to personas, and speaking to the AI coach. Further enhancements: making sure all colors and fonts are standardized.
<img width="674" height="789" alt="Screenshot 2026-02-04 at 7 26 38 PM" src="https://github.com/user-attachments/assets/4f336917-71b7-4dc4-a77c-b58cf7b45bec" />
<img width="660" height="785" alt="Screenshot 2026-02-04 at 7 26 59 PM" src="https://github.com/user-attachments/assets/a0c48530-f4b8-48ff-8c09-4fdc4aa3007d" />