### PR TITLE
Feat/split screen coach

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import type { AppRouter } from './api/trpc';
 import { TRPCProvider } from './api/trpc';
 import { UserMenu } from './components/UserMenu';
+import { ThemeToggle } from './components/ThemeToggle';
 import { AdminLayout } from './layouts/AdminLayout';
 import { ResearchLayout } from './layouts/ResearchLayout';
 import { Telemetry } from './pages/admin/Telemetry';
@@ -15,6 +16,7 @@ import { Invite } from './pages/Invite';
 import { InvitationDetail } from './pages/research/InvitationDetail';
 import { InvitationList } from './pages/research/InvitationList';
 import { ObserveSession } from './pages/research/ObserveSession';
+
 
 function makeQueryClient() {
   return new QueryClient({
@@ -92,20 +94,22 @@ export function App() {
             <Route
               path="*"
               element={
-                <div className="min-h-screen bg-gray-50">
+                <div className="min-h-screen bg-gray-50 dark:bg-gray-900">  {/* ADD dark: class */}
                   {siteBanner && (
                     <div
                       className="bg-amber-300 px-4 py-2 text-center text-sm font-medium text-black [&_a]:underline [&_a]:hover:text-amber-700"
-                      // biome-ignore lint/security/noDangerouslySetInnerHtml: admin-controlled env var, not user input
                       dangerouslySetInnerHTML={{ __html: siteBanner }}
                     />
                   )}
-                  <header className="bg-white shadow">
+                  <header className="bg-white dark:bg-gray-800 shadow">  {/* ADD dark: class */}
                     <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
-                      <h1 className="text-2xl font-bold tracking-tight text-gray-900">
+                      <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">  {/* ADD dark: class */}
                         ConvoLab Conversation Coach
                       </h1>
-                      <UserMenu />
+                      <div className="flex items-center gap-4">  {/* ADD THIS DIV */}
+                        <ThemeToggle />  {/* ADD THIS */}
+                        <UserMenu />
+                      </div>  {/* END DIV */}
                     </div>
                   </header>
                   <main>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -98,6 +98,7 @@ export function App() {
                   {siteBanner && (
                     <div
                       className="bg-amber-300 px-4 py-2 text-center text-sm font-medium text-black [&_a]:underline [&_a]:hover:text-amber-700"
+                      // biome-ignore lint/security/noDangerouslySetInnerHtml: Admin-controlled content only
                       dangerouslySetInnerHTML={{ __html: siteBanner }}
                     />
                   )}

--- a/packages/app/src/components/ScenarioList.tsx
+++ b/packages/app/src/components/ScenarioList.tsx
@@ -20,6 +20,15 @@ interface Scenario {
   partnerPersona: string;
 }
 
+interface Preset {
+  name: string;
+  label: string;
+  description?: string;
+  quota: {
+    tokens: number;
+  };
+}
+
 interface PresetModalProps {
   scenario: Scenario;
   onClose: () => void;
@@ -77,17 +86,17 @@ function PresetModal({ scenario, onClose }: PresetModalProps) {
       aria-labelledby="modal-title"
       tabIndex={-1}
     >
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
-        <h3 id="modal-title" className="text-lg font-semibold text-gray-900 mb-2">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+        <h3 id="modal-title" className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
           {scenario.name}
         </h3>
-        <p className="text-sm text-gray-600 mb-4">Choose a token quota for this conversation:</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">Choose a token quota for this conversation:</p>
 
         {presetsLoading ? (
-          <p className="text-gray-500 text-sm">Loading presets...</p>
+          <p className="text-gray-500 dark:text-gray-400 text-sm">Loading presets...</p>
         ) : (
           <div className="space-y-2 mb-4">
-            {presets?.map((preset) => (
+            {presets && Array.isArray(presets) && (presets as Preset[]).map((preset) => (
               <button
                 key={preset.name}
                 type="button"
@@ -95,12 +104,12 @@ function PresetModal({ scenario, onClose }: PresetModalProps) {
                 onClick={() => setSelectedPreset(preset.name)}
                 className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
                   selectedPreset === preset.name
-                    ? 'border-blue-500 bg-blue-50'
-                    : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                    ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                    : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700'
                 }`}
               >
-                <div className="font-medium text-gray-900">{preset.label}</div>
-                <div className="text-sm text-gray-500">
+                <div className="font-medium text-gray-900 dark:text-white">{preset.label}</div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
                   {preset.quota.tokens.toLocaleString()} tokens
                   {preset.description && ` — ${preset.description}`}
                 </div>
@@ -109,13 +118,13 @@ function PresetModal({ scenario, onClose }: PresetModalProps) {
           </div>
         )}
 
-        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        {error && <p className="text-red-600 dark:text-red-400 text-sm mb-4">{error}</p>}
 
         <div className="flex gap-3 justify-end">
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
           >
             Cancel
           </button>
@@ -123,7 +132,7 @@ function PresetModal({ scenario, onClose }: PresetModalProps) {
             type="button"
             onClick={handleStart}
             disabled={!selectedPreset || startSession.isPending}
-            className="px-4 py-2 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-4 py-2 text-sm text-white bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {startSession.isPending ? 'Starting...' : 'Start conversation'}
           </button>
@@ -211,7 +220,7 @@ function CustomScenarioModal({ onClose }: CustomScenarioModalProps) {
       aria-labelledby="custom-modal-title"
       tabIndex={-1}
     >
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6">
         {!confirmedScenario ? (
           // Step 1: Description input and elaboration (using shared component)
           <CustomScenarioForm
@@ -223,27 +232,27 @@ function CustomScenarioModal({ onClose }: CustomScenarioModalProps) {
         ) : (
           // Step 2: Preset selection
           <>
-            <div className="mb-4 rounded-lg bg-green-50 border border-green-200 p-4">
-              <p className="text-xs text-green-600 font-medium mb-1">Your conversation partner:</p>
-              <p className="text-sm font-semibold text-gray-900">
+            <div className="mb-4 rounded-lg bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 p-4">
+              <p className="text-xs text-green-600 dark:text-green-400 font-medium mb-1">Your conversation partner:</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">
                 {confirmedScenario.elaborated.name}
               </p>
-              <p className="text-sm text-gray-600 mt-1">{confirmedScenario.elaborated.persona}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{confirmedScenario.elaborated.persona}</p>
               <button
                 type="button"
                 onClick={handleBack}
-                className="mt-2 text-xs text-green-700 hover:text-green-800 underline"
+                className="mt-2 text-xs text-green-700 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 underline"
               >
                 Edit description
               </button>
             </div>
 
-            <p className="text-sm text-gray-600 mb-2">Choose a token quota:</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Choose a token quota:</p>
             {presetsLoading ? (
-              <p className="text-gray-500 text-sm">Loading presets...</p>
+              <p className="text-gray-500 dark:text-gray-400 text-sm">Loading presets...</p>
             ) : (
               <div className="space-y-2 mb-4">
-                {presets?.map((preset) => (
+                {presets && Array.isArray(presets) && (presets as Preset[]).map((preset) => (
                   <button
                     key={preset.name}
                     type="button"
@@ -251,12 +260,12 @@ function CustomScenarioModal({ onClose }: CustomScenarioModalProps) {
                     onClick={() => setSelectedPreset(preset.name)}
                     className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
                       selectedPreset === preset.name
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                        ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                        : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700'
                     }`}
                   >
-                    <div className="font-medium text-gray-900">{preset.label}</div>
-                    <div className="text-sm text-gray-500">
+                    <div className="font-medium text-gray-900 dark:text-white">{preset.label}</div>
+                    <div className="text-sm text-gray-500 dark:text-gray-400">
                       {preset.quota.tokens.toLocaleString()} tokens
                       {preset.description && ` — ${preset.description}`}
                     </div>
@@ -265,13 +274,13 @@ function CustomScenarioModal({ onClose }: CustomScenarioModalProps) {
               </div>
             )}
 
-            {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+            {error && <p className="text-red-600 dark:text-red-400 text-sm mb-4">{error}</p>}
 
             <div className="flex gap-3 justify-end">
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+                className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
               >
                 Cancel
               </button>
@@ -279,7 +288,7 @@ function CustomScenarioModal({ onClose }: CustomScenarioModalProps) {
                 type="button"
                 onClick={handleStart}
                 disabled={!selectedPreset || startSession.isPending}
-                className="px-4 py-2 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 text-sm text-white bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {startSession.isPending ? 'Starting...' : 'Start conversation'}
               </button>
@@ -299,32 +308,32 @@ export function ScenarioList() {
   const { data: scenarios, isLoading, isError } = useQuery(trpc.scenario.list.queryOptions());
 
   if (isLoading) {
-    return <p className="text-gray-500">Loading scenarios...</p>;
+    return <p className="text-gray-500 dark:text-gray-400">Loading scenarios...</p>;
   }
 
   if (isError) {
-    return <p className="text-red-500">Error loading scenarios. Please try again later.</p>;
+    return <p className="text-red-500 dark:text-red-400">Error loading scenarios. Please try again later.</p>;
   }
 
-  if (!scenarios?.length) {
-    return <p className="text-gray-500">No scenarios available.</p>;
+  if (!scenarios || !Array.isArray(scenarios) || scenarios.length === 0) {
+    return <p className="text-gray-500 dark:text-gray-400">No scenarios available.</p>;
   }
 
   return (
     <>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {scenarios.map((scenario) => (
+        {(scenarios as Scenario[]).map((scenario) => (
           <button
             key={scenario.id}
             type="button"
             onClick={() => setSelectedScenario(scenario)}
-            className="text-left rounded-lg bg-white p-6 shadow hover:shadow-md hover:border-blue-300 border border-transparent transition-all"
+            className="text-left rounded-lg bg-white dark:bg-gray-800 p-6 shadow hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 border border-transparent dark:border-gray-700 transition-all"
           >
-            <h2 className="text-lg font-semibold text-gray-900">{scenario.name}</h2>
-            <p className="mt-2 text-sm text-gray-600 line-clamp-2">{scenario.description}</p>
-            <div className="mt-4 rounded bg-gray-50 px-3 py-2">
-              <p className="text-xs text-gray-500">You'll talk with:</p>
-              <p className="text-sm text-gray-700">{scenario.partnerPersona}</p>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{scenario.name}</h2>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{scenario.description}</p>
+            <div className="mt-4 rounded bg-gray-50 dark:bg-gray-700 px-3 py-2">
+              <p className="text-xs text-gray-500 dark:text-gray-400">You'll talk with:</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">{scenario.partnerPersona}</p>
             </div>
           </button>
         ))}
@@ -333,15 +342,15 @@ export function ScenarioList() {
         <button
           type="button"
           onClick={() => setShowCustomModal(true)}
-          className="text-left rounded-lg bg-gradient-to-br from-indigo-50 to-purple-50 p-6 shadow hover:shadow-md hover:border-indigo-300 border border-dashed border-indigo-200 transition-all"
+          className="text-left rounded-lg bg-gradient-to-br from-indigo-50 to-purple-50 dark:from-indigo-900/30 dark:to-purple-900/30 p-6 shadow hover:shadow-md hover:border-indigo-300 dark:hover:border-indigo-600 border border-dashed border-indigo-200 dark:border-indigo-700 transition-all"
         >
-          <h2 className="text-lg font-semibold text-indigo-900">Create Your Own</h2>
-          <p className="mt-2 text-sm text-indigo-700">
+          <h2 className="text-lg font-semibold text-indigo-900 dark:text-indigo-100">Create Your Own</h2>
+          <p className="mt-2 text-sm text-indigo-700 dark:text-indigo-300">
             Describe any conversation partner you want to practice with.
           </p>
-          <div className="mt-4 rounded bg-white/60 px-3 py-2">
-            <p className="text-xs text-indigo-500">You'll describe:</p>
-            <p className="text-sm text-indigo-800">Anyone you need to talk to</p>
+          <div className="mt-4 rounded bg-white/60 dark:bg-gray-800/60 px-3 py-2">
+            <p className="text-xs text-indigo-500 dark:text-indigo-400">You'll describe:</p>
+            <p className="text-sm text-indigo-800 dark:text-indigo-200">Anyone you need to talk to</p>
           </div>
         </button>
       </div>

--- a/packages/app/src/components/ThemeToggle.tsx
+++ b/packages/app/src/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+import { useTheme } from '../contexts/ThemeContext';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 
+                 hover:bg-gray-300 dark:hover:bg-gray-600 
+                 transition-colors"
+      aria-label="Toggle theme"
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      {theme === 'dark' ? '☀️' : '🌙'}
+    </button>
+  );
+}

--- a/packages/app/src/components/YourSessions.tsx
+++ b/packages/app/src/components/YourSessions.tsx
@@ -2,6 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useTRPC } from '../api/trpc';
 
+interface Session {
+  id: number;
+  startedAt: string | Date;
+  messageCount: number;
+  scenario?: {
+    name: string;
+    partnerPersona?: string;
+  };
+}
+
 /** Format a date as a relative time string (e.g., "5m ago", "2d ago") */
 function formatRelativeTime(date: string | Date): string {
   const d = new Date(date);
@@ -36,9 +46,9 @@ export function YourSessions() {
   // Show welcome message for unauthenticated users
   if (!isLoading && !authData?.user) {
     return (
-      <div className="mb-8 rounded-lg border border-blue-200 bg-blue-50 p-6">
-        <h2 className="text-lg font-medium text-gray-900 mb-2">Welcome</h2>
-        <p className="text-gray-600">
+      <div className="mb-8 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 p-6">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-2">Welcome</h2>
+        <p className="text-gray-600 dark:text-gray-300">
           Sign in or use an invitation link to start practicing conversations.
         </p>
       </div>
@@ -46,30 +56,30 @@ export function YourSessions() {
   }
 
   // Don't render anything if loading or no sessions
-  if (isLoading || !sessions?.length) {
+  if (isLoading || !sessions || !Array.isArray(sessions) || sessions.length === 0) {
     return null;
   }
 
   return (
     <div className="mb-8">
-      <h2 className="text-lg font-medium text-gray-900 mb-4">Your Conversations</h2>
+      <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Your Conversations</h2>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {sessions.map((session) => (
+        {(sessions as Session[]).map((session) => (
           <button
             key={session.id}
             type="button"
             onClick={() => navigate(`/conversation/${session.id}`)}
-            className="text-left rounded-lg border bg-white p-4 shadow-sm hover:shadow-md hover:border-blue-300 transition-all"
+            className="text-left rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 transition-all"
           >
-            <div className="font-medium text-gray-900">
+            <div className="font-medium text-gray-900 dark:text-white">
               {session.scenario?.name || 'Conversation'}
             </div>
             {session.scenario?.partnerPersona && (
-              <div className="text-sm text-gray-500 mt-1">
+              <div className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                 with {session.scenario.partnerPersona}
               </div>
             )}
-            <div className="flex items-center justify-between mt-3 text-xs text-gray-400">
+            <div className="flex items-center justify-between mt-3 text-xs text-gray-400 dark:text-gray-500">
               <span>{session.messageCount} messages</span>
               <span>{formatRelativeTime(session.startedAt)}</span>
             </div>

--- a/packages/app/src/components/conversation/AsideButton.tsx
+++ b/packages/app/src/components/conversation/AsideButton.tsx
@@ -9,7 +9,7 @@ export function AsideButton({ onClick, disabled }: AsideButtonProps) {
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex items-center justify-center h-10 w-10 rounded-full bg-amber-500 text-white shadow-lg hover:bg-amber-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+      className="flex items-center justify-center h-10 w-10 rounded-full bg-amber-500 dark:bg-amber-600 text-white shadow-lg hover:bg-amber-600 dark:hover:bg-amber-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
       title="Ask Coach"
       aria-label="Ask Coach a question"
     >

--- a/packages/app/src/components/conversation/AsidePanel.tsx
+++ b/packages/app/src/components/conversation/AsidePanel.tsx
@@ -10,8 +10,8 @@ const markdownClasses = `
   [&_ul]:list-disc [&_ul]:ml-4 [&_ul]:my-2
   [&_ol]:list-decimal [&_ol]:ml-4 [&_ol]:my-2
   [&_li]:my-1
-  [&_code]:bg-black/10 [&_code]:px-1 [&_code]:rounded [&_code]:text-sm
-  [&_pre]:bg-black/10 [&_pre]:p-2 [&_pre]:rounded [&_pre]:overflow-x-auto [&_pre]:my-2
+  [&_code]:bg-black/10 dark:bg-white/10 [&_code]:px-1 [&_code]:rounded [&_code]:text-sm
+  [&_pre]:bg-black/10 dark:bg-white/10 [&_pre]:p-2 [&_pre]:rounded [&_pre]:overflow-x-auto [&_pre]:my-2
   [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:my-2
   [&_hr]:my-3 [&_hr]:border-current [&_hr]:opacity-30
 `.trim();
@@ -33,7 +33,7 @@ function AsideMessageBubble({ message }: { message: AsideMessage }) {
     return (
       <div className="flex justify-end">
         <div
-          className={`max-w-[85%] rounded-lg px-3 py-2 bg-amber-500 text-white ${markdownClasses}`}
+          className={`max-w-[85%] rounded-lg px-3 py-2 bg-amber-500 dark:bg-amber-600 text-white ${markdownClasses}`}
         >
           <Markdown>{content}</Markdown>
         </div>
@@ -45,7 +45,7 @@ function AsideMessageBubble({ message }: { message: AsideMessage }) {
   return (
     <div className="flex justify-start">
       <div
-        className={`max-w-[85%] rounded-lg px-3 py-2 bg-gray-100 text-gray-900 ${markdownClasses}`}
+        className={`max-w-[85%] rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 ${markdownClasses}`}
       >
         <Markdown>{content}</Markdown>
         {isStreaming && <span className="ml-1 animate-pulse">|</span>}
@@ -110,7 +110,7 @@ export function AsidePanel({
       {isOpen && (
         <button
           type="button"
-          className="fixed inset-0 bg-black/30 transition-opacity duration-200 md:hidden cursor-default"
+          className="fixed inset-0 bg-black/30 dark:bg-black/50 transition-opacity duration-200 md:hidden cursor-default"
           onClick={handleClose}
           aria-label="Close aside panel"
         />
@@ -118,7 +118,7 @@ export function AsidePanel({
 
       {/* Panel */}
       <div
-        className={`fixed z-50 bg-white shadow-xl flex flex-col transform transition-transform duration-300 ease-out
+        className={`fixed z-50 bg-white dark:bg-gray-800 shadow-xl flex flex-col transform transition-transform duration-300 ease-out
           bottom-0 left-0 w-full h-[85vh] rounded-t-2xl md:rounded-none
           md:top-0 md:right-0 md:h-full md:w-[400px] md:bottom-auto md:left-auto
           ${isOpen
@@ -130,12 +130,12 @@ export function AsidePanel({
         aria-hidden={!isOpen}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b bg-amber-50 rounded-t-2xl md:rounded-none">
-          <h2 className="text-lg font-semibold text-amber-900">Ask Coach</h2>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 rounded-t-2xl md:rounded-none">
+          <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100">Ask Coach</h2>
           <button
             type="button"
             onClick={handleClose}
-            className="p-1 rounded hover:bg-amber-100 text-amber-700"
+            className="p-1 rounded hover:bg-amber-100 dark:hover:bg-amber-800 text-amber-700 dark:text-amber-300"
             aria-label="Close panel"
           >
             <svg
@@ -154,9 +154,9 @@ export function AsidePanel({
         </div>
 
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        <div className="flex-1 overflow-y-auto p-4 space-y-3 bg-white dark:bg-gray-800">
           {messages.length === 0 && !isStreaming && (
-            <div className="text-center text-gray-500 text-sm py-8">
+            <div className="text-center text-gray-500 dark:text-gray-400 text-sm py-8">
               <p>Ask the coach a private question.</p>
               <p className="mt-2 text-xs">
                 The coach can see your full conversation and will provide focused guidance.
@@ -171,13 +171,13 @@ export function AsidePanel({
 
         {/* Error message */}
         {error && (
-          <div className="px-4 py-2 bg-red-50 text-red-700 text-sm border-t border-red-200">
+          <div className="px-4 py-2 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-sm border-t border-red-200 dark:border-red-800">
             {error.message}
           </div>
         )}
 
         {/* Input form */}
-        <form onSubmit={handleSubmit} className="border-t bg-white p-3">
+        <form onSubmit={handleSubmit} className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
           <div className="flex gap-2">
             <textarea
               ref={inputRef}
@@ -188,13 +188,13 @@ export function AsidePanel({
               disabled={isStreaming}
               rows={1}
               aria-label="Question input"
-              className="flex-1 resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500 disabled:bg-gray-100 disabled:text-gray-500"
+              className="flex-1 resize-none rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-3 py-2 text-sm focus:border-amber-500 dark:focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-500 dark:focus:ring-amber-400 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-gray-500 dark:disabled:text-gray-500"
             />
             {isStreaming ? (
               <button
                 type="button"
                 onClick={onCancel}
-                className="rounded-lg bg-red-500 px-4 py-2 text-white hover:bg-red-600 text-sm"
+                className="rounded-lg bg-red-500 dark:bg-red-600 px-4 py-2 text-white hover:bg-red-600 dark:hover:bg-red-700 text-sm"
               >
                 Cancel
               </button>
@@ -202,7 +202,7 @@ export function AsidePanel({
               <button
                 type="submit"
                 disabled={!question.trim()}
-                className="rounded-lg bg-amber-500 px-4 py-2 text-white hover:bg-amber-600 disabled:bg-gray-300 disabled:cursor-not-allowed text-sm"
+                className="rounded-lg bg-amber-500 dark:bg-amber-600 px-4 py-2 text-white hover:bg-amber-600 dark:hover:bg-amber-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:cursor-not-allowed text-sm"
               >
                 Ask
               </button>

--- a/packages/app/src/components/conversation/MessageBubble.tsx
+++ b/packages/app/src/components/conversation/MessageBubble.tsx
@@ -5,29 +5,29 @@ interface MessageBubbleProps {
   message: Message;
 }
 
-// Prose-like styling for markdown content
+// Prose-like styling for markdown content with MUCH LARGER fonts
 const markdownClasses = `
-  [&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0
+  [&_p]:my-3 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_p]:text-xl [&_p]:leading-relaxed
   [&_strong]:font-semibold
   [&_em]:italic
-  [&_ul]:list-disc [&_ul]:ml-4 [&_ul]:my-2
-  [&_ol]:list-decimal [&_ol]:ml-4 [&_ol]:my-2
-  [&_li]:my-1
-  [&_code]:bg-black/10 [&_code]:px-1 [&_code]:rounded [&_code]:text-sm
-  [&_pre]:bg-black/10 [&_pre]:p-2 [&_pre]:rounded [&_pre]:overflow-x-auto [&_pre]:my-2
-  [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:my-2
-  [&_hr]:my-3 [&_hr]:border-current [&_hr]:opacity-30
+  [&_ul]:list-disc [&_ul]:ml-5 [&_ul]:my-3 [&_ul]:text-xl
+  [&_ol]:list-decimal [&_ol]:ml-5 [&_ol]:my-3 [&_ol]:text-xl
+  [&_li]:my-2 [&_li]:text-xl
+  [&_code]:bg-black/10 dark:bg-white/10 [&_code]:px-1.5 [&_code]:rounded [&_code]:text-base
+  [&_pre]:bg-black/10 dark:bg-white/10 [&_pre]:p-3 [&_pre]:rounded [&_pre]:overflow-x-auto [&_pre]:my-3 [&_pre]:text-base
+  [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:my-3 [&_blockquote]:text-xl
+  [&_hr]:my-4 [&_hr]:border-current [&_hr]:opacity-30
 `.trim();
 
 export function MessageBubble({ message }: MessageBubbleProps) {
   const { role, content, isStreaming } = message;
 
-  const baseClasses = 'max-w-[80%] rounded-lg px-4 py-2';
+  const baseClasses = 'max-w-[85%] rounded-2xl px-6 py-4';
 
   if (role === 'user') {
     return (
       <div className="flex justify-end">
-        <div className={`${baseClasses} bg-gray-200 text-gray-900 ${markdownClasses}`}>
+        <div className={`${baseClasses} bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-xl ${markdownClasses}`}>
           <Markdown>{content}</Markdown>
         </div>
       </div>
@@ -37,24 +37,23 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   if (role === 'partner') {
     return (
       <div className="flex justify-start">
-        <div className={`${baseClasses} bg-white text-gray-900 border border-gray-200 shadow-sm ${markdownClasses}`}>
+        <div className={`${baseClasses} bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 shadow-sm text-xl ${markdownClasses}`}>
           <Markdown>{content}</Markdown>
-          {isStreaming && <span className="ml-1 animate-pulse">|</span>}
+          {isStreaming && <span className="ml-1 animate-pulse text-xl">|</span>}
         </div>
       </div>
     );
   }
 
   // Coach message - centered with distinct styling
-  // User requested "Yellow" if uncle is white.
   return (
     <div className="flex justify-center">
       <div
-        className={`${baseClasses} bg-yellow-100 text-yellow-900 border border-yellow-200 text-sm ${markdownClasses}`}
+        className={`${baseClasses} bg-yellow-100 dark:bg-yellow-900/30 text-yellow-900 dark:text-yellow-100 border border-yellow-200 dark:border-yellow-700 ${markdownClasses}`}
       >
-        <span className="font-semibold block mb-1">Coach:</span>
+        <span className="font-semibold block mb-2 text-xl">Coach:</span>
         <Markdown>{content}</Markdown>
-        {isStreaming && <span className="ml-1 animate-pulse">|</span>}
+        {isStreaming && <span className="ml-1 animate-pulse text-xl">|</span>}
       </div>
     </div>
   );

--- a/packages/app/src/components/conversation/MessageInput.tsx
+++ b/packages/app/src/components/conversation/MessageInput.tsx
@@ -29,8 +29,8 @@ export function MessageInput({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="border-t bg-white p-4">
-      <div className="flex gap-2">
+    <form onSubmit={handleSubmit} className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+      <div className="flex gap-3 items-end">
         <textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
@@ -39,12 +39,12 @@ export function MessageInput({
           disabled={disabled}
           rows={1}
           aria-label="Message input"
-          className="flex-1 resize-none rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
+          className="flex-1 resize-none rounded-3xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-5 py-3 text-lg focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-gray-500 dark:disabled:text-gray-500"
         />
         <button
           type="submit"
           disabled={disabled || !content.trim()}
-          className="rounded-lg bg-blue-600 px-6 py-2 text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          className="rounded-2xl bg-blue-600 dark:bg-blue-500 px-8 py-3 text-lg font-medium text-white hover:bg-blue-700 dark:hover:bg-blue-600 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
         >
           Send
         </button>

--- a/packages/app/src/components/conversation/MessageList.tsx
+++ b/packages/app/src/components/conversation/MessageList.tsx
@@ -21,7 +21,7 @@ export function MessageList({ messages, isStreaming }: MessageListProps) {
 
   if (messages.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-gray-500">
+      <div className="flex-1 flex items-center justify-center text-gray-500 dark:text-gray-400">
         <p>Send a message to start the conversation</p>
       </div>
     );

--- a/packages/app/src/components/conversation/MobileMessageInput.tsx
+++ b/packages/app/src/components/conversation/MobileMessageInput.tsx
@@ -64,7 +64,7 @@ export function MobileMessageInput({
     };
 
     return (
-        <div className="border-t bg-white p-2">
+        <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
             {/* Input Row */}
             <form onSubmit={handleSubmit} className="flex gap-2">
                 <div className="relative" ref={dropdownRef}>
@@ -72,7 +72,7 @@ export function MobileMessageInput({
                     <button
                         type="button"
                         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                        className={`flex h-10 w-12 items-center justify-center rounded-xl bg-gray-50 text-gray-900 border border-gray-200 ${isDropdownOpen ? 'bg-gray-100' : ''}`}
+                        className={`flex h-12 w-14 items-center justify-center rounded-2xl bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-600 ${isDropdownOpen ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
                         aria-label="Switch partner"
                     >
                         {activeIcon(recipient)}
@@ -83,40 +83,40 @@ export function MobileMessageInput({
 
                     {/* Dropdown Menu Positioned bottom-up or just above */}
                     {isDropdownOpen && (
-                        <div className="absolute bottom-12 left-0 w-64 rounded-2xl border border-gray-100 bg-white p-2 shadow-xl ring-1 ring-black/5 z-20">
+                        <div className="absolute bottom-14 left-0 w-72 rounded-2xl border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 p-2 shadow-xl ring-1 ring-black/5 dark:ring-white/5 z-20">
                             <button
                                 type="button"
                                 onClick={() => handleRecipientSelect('partner')}
-                                className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors ${recipient === 'partner' ? 'bg-gray-50' : 'hover:bg-gray-50'
+                                className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition-colors ${recipient === 'partner' ? 'bg-gray-50 dark:bg-gray-700' : 'hover:bg-gray-50 dark:hover:bg-gray-700'
                                     }`}
                             >
-                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+                                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-6 h-6" aria-hidden="true">
                                         <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.957 9.957 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 0 0-13.074.003Z" />
                                     </svg>
                                 </div>
                                 <div>
-                                    <div className="font-semibold text-gray-900">{partnerName}</div>
-                                    <div className="text-xs text-gray-500">Practice conversation</div>
+                                    <div className="font-semibold text-base text-gray-900 dark:text-gray-100">{partnerName}</div>
+                                    <div className="text-sm text-gray-500 dark:text-gray-400">Practice conversation</div>
                                 </div>
                             </button>
 
                             <button
                                 type="button"
                                 onClick={() => handleRecipientSelect('coach')}
-                                className={`mt-1 flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors ${recipient === 'coach' ? 'bg-gray-50' : 'hover:bg-gray-50'
+                                className={`mt-1 flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition-colors ${recipient === 'coach' ? 'bg-gray-50 dark:bg-gray-700' : 'hover:bg-gray-50 dark:hover:bg-gray-700'
                                     }`}
                             >
-                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" aria-hidden="true">
+                                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6" aria-hidden="true">
                                         <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
                                         <path d="M9 18h6" />
                                         <path d="M10 22h4" />
                                     </svg>
                                 </div>
                                 <div>
-                                    <div className="font-semibold text-gray-900">Conversation Coach</div>
-                                    <div className="text-xs text-gray-500">Ask for advice</div>
+                                    <div className="font-semibold text-base text-gray-900 dark:text-gray-100">Conversation Coach</div>
+                                    <div className="text-sm text-gray-500 dark:text-gray-400">Ask for advice</div>
                                 </div>
                             </button>
                         </div>
@@ -132,20 +132,20 @@ export function MobileMessageInput({
                     placeholder={recipient === 'partner' ? `Reply to ${partnerName}...` : "Ask the coach..."}
                     disabled={disabled}
                     rows={1}
-                    className="flex-1 resize-none rounded-xl border border-gray-200 px-4 py-2.5 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-100 disabled:text-gray-500"
+                    className="flex-1 resize-none rounded-3xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-5 py-3 text-base shadow-sm focus:border-teal-500 dark:focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500 dark:focus:ring-teal-400 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-gray-500 dark:disabled:text-gray-500"
                 />
 
                 {/* Insights Toggle */}
                 <button
                     type="button"
                     onClick={onToggleInsights}
-                    className={`flex h-10 w-10 items-center justify-center rounded-xl border transition-colors ${isInsightsOpen
-                        ? 'bg-teal-100 text-teal-700 border-teal-200'
-                        : 'bg-white text-gray-500 border-gray-200 hover:bg-gray-50'
+                    className={`flex h-12 w-12 items-center justify-center rounded-2xl border transition-colors ${isInsightsOpen
+                        ? 'bg-teal-100 dark:bg-teal-900 text-teal-700 dark:text-teal-300 border-teal-200 dark:border-teal-700'
+                        : 'bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
                         }`}
                     aria-label="Toggle insights"
                 >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6" aria-hidden="true">
                         <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
                         <path d="M9 18h6" />
                         <path d="M10 22h4" />
@@ -155,10 +155,10 @@ export function MobileMessageInput({
                 <button
                     type="submit"
                     disabled={disabled || !content.trim()}
-                    className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-50 text-gray-400 hover:text-teal-600 disabled:opacity-50"
+                    className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gray-50 dark:bg-gray-700 text-gray-400 dark:text-gray-500 hover:text-teal-600 dark:hover:text-teal-400 disabled:opacity-50"
                     aria-label="Send message"
                 >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5 -rotate-45 translate-x-0.5 -translate-y-0.5" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6 -rotate-45 translate-x-0.5 -translate-y-0.5" aria-hidden="true">
                         <path d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z" />
                     </svg>
                 </button>
@@ -170,17 +170,16 @@ export function MobileMessageInput({
 function activeIcon(recipient: Recipient) {
     if (recipient === 'partner') {
         return (
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-6 h-6" aria-hidden="true">
                 <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.957 9.957 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 0 0-13.074.003Z" />
             </svg>
         );
     }
     return (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6" aria-hidden="true">
             <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
             <path d="M9 18h6" />
             <path d="M10 22h4" />
         </svg>
     )
 }
-

--- a/packages/app/src/contexts/ThemeContext.tsx
+++ b/packages/app/src/contexts/ThemeContext.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    // Check localStorage first
+    const saved = localStorage.getItem('theme') as Theme;
+    if (saved) return saved;
+    
+    // Then check system preference
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
 import './index.css';
+import { ThemeProvider } from './contexts/ThemeContext';  
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>  {}
+      <App />
+    </ThemeProvider>  {}
   </React.StrictMode>
 );

--- a/packages/app/src/pages/Conversation.tsx
+++ b/packages/app/src/pages/Conversation.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, useRef, useEffect } from 'react';
+import { type ReactNode, useRef, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { MessageInput } from '../components/conversation/MessageInput';
 import { MessageList } from '../components/conversation/MessageList';

--- a/packages/app/src/pages/Conversation.tsx
+++ b/packages/app/src/pages/Conversation.tsx
@@ -75,7 +75,6 @@ const markdownClasses = `
 
 function ConversationContent({ sessionId }: { sessionId: number }) {
   const navigate = useNavigate();
-  const [isInputFocused, setIsInputFocused] = useState(false);
   const coachMessagesEndRef = useRef<HTMLDivElement>(null);
   const coachInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -101,6 +100,7 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
   };
 
   // Auto-scroll coach messages
+  // biome-ignore lint/correctness/useExhaustiveDependencies: asideMessages triggers scroll
   useEffect(() => {
     if (coachMessagesEndRef.current) {
       coachMessagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -161,7 +161,7 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
 
   const handleCoachSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (coachInputRef.current && coachInputRef.current.value.trim() && !isAsideStreaming) {
+    if (coachInputRef.current?.value.trim() && !isAsideStreaming) {
       startAside(coachInputRef.current.value.trim());
       coachInputRef.current.value = '';
     }
@@ -200,8 +200,8 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
         </div>
       </header>
 
-      {/* SPLIT SCREEN LAYOUT - Centered together with margins */}
-      <div className="flex-1 flex overflow-hidden justify-center px-8">
+      {/* SPLIT SCREEN LAYOUT - Centered with small gap */}
+      <div className="flex-1 flex overflow-hidden justify-center px-8 gap-3">
         
         {/* LEFT SIDE: Main Conversation */}
         <div className="flex w-full max-w-4xl flex-col">
@@ -257,15 +257,15 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
                 disabled={isStreaming || isAsideStreaming || quota?.exhausted || false}
                 isInsightsOpen={false}
                 onToggleInsights={() => {}}
-                onInputFocus={() => setIsInputFocused(true)}
-                onInputBlur={() => setIsInputFocused(false)}
+                onInputFocus={() => {}}
+                onInputBlur={() => {}}
               />
             </div>
           </div>
         </div>
 
-        {/* RIGHT SIDE: Coach Panel - Rounded on BOTH sides */}
-        <div className="hidden md:flex md:w-[32rem] lg:w-[36rem] flex-col bg-white dark:bg-gray-800 border-l-2 border-r-2 border-gray-300 dark:border-gray-600 rounded-2xl shadow-lg overflow-hidden">
+        {/* RIGHT SIDE: Coach Panel - Shadow only, no borders */}
+        <div className="hidden md:flex md:w-[32rem] lg:w-[36rem] flex-col bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden">
           
           {/* Coach header */}
           <div className="border-b border-gray-200 dark:border-gray-700 bg-yellow-50 dark:bg-yellow-900/20 px-5 py-4">

--- a/packages/app/src/pages/Conversation.tsx
+++ b/packages/app/src/pages/Conversation.tsx
@@ -7,12 +7,13 @@ import { MessageList } from '../components/conversation/MessageList';
 import { useConversationSocket } from '../hooks/useConversationSocket';
 import { MobileMessageInput } from '../components/conversation/MobileMessageInput';
 import { CoachInsightsPanel } from '../components/conversation/CoachInsightsPanel';
+import { ThemeToggle } from '../components/ThemeToggle';
 
 
 /** Full-screen centered message with optional title, message, and action button */
 function FullScreenMessage({
   title,
-  titleColor = 'text-gray-900',
+  titleColor = 'text-gray-900 dark:text-white',
   message,
   action,
 }: {
@@ -22,10 +23,10 @@ function FullScreenMessage({
   action?: ReactNode;
 }) {
   return (
-    <div className="flex h-dvh items-center justify-center">
+    <div className="flex h-dvh items-center justify-center bg-gray-50 dark:bg-gray-900">
       <div className="text-center">
         {title && <h1 className={`text-2xl font-bold ${titleColor}`}>{title}</h1>}
-        {message && <div className="mt-2 text-gray-600">{message}</div>}
+        {message && <div className="mt-2 text-gray-600 dark:text-gray-400">{message}</div>}
         {action && <div className="mt-4">{action}</div>}
       </div>
     </div>
@@ -42,13 +43,13 @@ export function Conversation() {
     return (
       <FullScreenMessage
         title="Invalid Session"
-        titleColor="text-red-600"
+        titleColor="text-red-600 dark:text-red-400"
         message="The session ID is not valid."
         action={
           <button
             type="button"
             onClick={() => navigate('/')}
-            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
           >
             Go Home
           </button>
@@ -105,9 +106,9 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
       <FullScreenMessage
         message={
           <output aria-live="polite">
-            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-blue-600 dark:border-blue-400 border-t-transparent" />
             <span className="sr-only">Loading</span>
-            <p className="mt-4">Connecting...</p>
+            <p className="mt-4 text-gray-900 dark:text-white">Connecting...</p>
           </output>
         }
       />
@@ -119,13 +120,13 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
     return (
       <FullScreenMessage
         title="Connection Error"
-        titleColor="text-red-600"
+        titleColor="text-red-600 dark:text-red-400"
         message={error.message}
         action={
           <button
             type="button"
             onClick={() => window.location.reload()}
-            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
           >
             Refresh Page
           </button>
@@ -148,58 +149,52 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
 
   const statusText = getStatusIndicator();
 
-
+  // Filter out aside messages from the main conversation view
+  const mainMessages = messages.filter(m => !('asideThreadId' in m));
 
   return (
 
-    <div className="flex h-dvh flex-col">
+    <div className="flex h-dvh flex-col bg-gray-50 dark:bg-gray-900">
       {/* Header */}
-      <header className="border-b bg-white px-4 py-3">
-        <div className="mx-auto flex max-w-3xl items-center justify-between">
+      <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-3">
+        <div className="mx-auto flex max-w-6xl items-center justify-between">
           <div>
-            <h1 className="text-lg font-semibold text-gray-900">
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
               {scenario?.name || 'Conversation'}
             </h1>
             {scenario?.partnerPersona && (
-              <p className="text-sm text-gray-500">Talking with: {scenario.partnerPersona}</p>
+              <p className="text-base text-gray-500 dark:text-gray-400">Talking with: {scenario.partnerPersona}</p>
             )}
           </div>
-          <button
-            type="button"
-            onClick={handleLeave}
-            className="rounded border border-gray-300 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-          >
-            Leave
-          </button>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <button
+              type="button"
+              onClick={handleLeave}
+              className="rounded border border-gray-300 dark:border-gray-600 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              Leave
+            </button>
+          </div>
         </div>
       </header>
 
-      {/* Messages area */}
-      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col overflow-hidden">
-        {/* Render merged list of main messages AND coach messages */}
+      {/* Messages area - WIDER max-width */}
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col overflow-hidden">
+        {/* Render ONLY main messages (not aside messages) */}
         <MessageList
-          messages={[
-            ...messages,
-            ...asideMessages.map(m => ({
-              ...m,
-              // Map 'coach' role to 'coach' (already matches)
-              // Map 'user' role in aside to 'user' (already matches)
-              // Ensure it has required Message fields
-              messageType: 'aside' as const,
-              asideThreadId: m.threadId
-            }))
-          ].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())}
-          isStreaming={isStreaming || isAsideStreaming}
+          messages={mainMessages}
+          isStreaming={isStreaming}
         />
 
         {/* Status indicator */}
         {statusText && (
-          <div className="px-4 py-2 text-center text-sm text-gray-500">{statusText}</div>
+          <div className="px-4 py-2 text-center text-base text-gray-500 dark:text-gray-400">{statusText}</div>
         )}
 
         {/* Quota warning */}
         {quota && !quota.exhausted && quota.remaining < quota.total * 0.2 && (
-          <div className="bg-amber-50 px-4 py-2 text-center text-sm text-amber-700">
+          <div className="bg-amber-50 dark:bg-amber-900/30 px-4 py-2 text-center text-base text-amber-700 dark:text-amber-300">
             Low quota: {quota.remaining.toLocaleString()} / {quota.total.toLocaleString()} tokens
             remaining
           </div>
@@ -207,14 +202,14 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
 
         {/* Quota exhausted */}
         {quota?.exhausted && (
-          <div className="bg-red-50 px-4 py-2 text-center text-sm text-red-700">
+          <div className="bg-red-50 dark:bg-red-900/30 px-4 py-2 text-center text-base text-red-700 dark:text-red-300">
             Quota exhausted. You can no longer send messages.
           </div>
         )}
 
         {/* Recoverable error */}
         {error?.recoverable && (
-          <div className="bg-red-50 px-4 py-2 text-center text-sm text-red-700">
+          <div className="bg-red-50 dark:bg-red-900/30 px-4 py-2 text-center text-base text-red-700 dark:text-red-300">
             {error.message}
           </div>
         )}
@@ -240,7 +235,7 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
             type="button"
             onClick={handleAsideOpen}
             disabled={isStreaming || quota?.exhausted || false}
-            className="absolute left-1/2 -top-10 -translate-x-1/2 flex items-center justify-center h-8 w-12 rounded-t-lg bg-amber-500 text-white shadow-lg md:hidden hover:bg-amber-600 disabled:bg-gray-300"
+            className="absolute left-1/2 -top-10 -translate-x-1/2 flex items-center justify-center h-8 w-12 rounded-t-lg bg-amber-500 dark:bg-amber-600 text-white shadow-lg md:hidden hover:bg-amber-600 dark:hover:bg-amber-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
             aria-label="Ask Coach"
           >
             <svg
@@ -288,22 +283,22 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
 
       {/* Quota bar at bottom */}
       {quota && (
-        <div className="border-t bg-gray-50 px-4 py-2 hidden md:block">
+        <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2 hidden md:block">
 
-          <div className="mx-auto max-w-3xl">
-            <div className="flex items-center justify-between text-xs text-gray-500">
+          <div className="mx-auto max-w-6xl">
+            <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
               <span>Token usage</span>
               <span>
                 {(quota.total - quota.remaining).toLocaleString()} / {quota.total.toLocaleString()}
               </span>
             </div>
-            <div className="mt-1 h-1.5 w-full rounded-full bg-gray-200">
+            <div className="mt-1 h-1.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
               <div
                 className={`h-1.5 rounded-full transition-all ${quota.exhausted
-                  ? 'bg-red-500'
+                  ? 'bg-red-500 dark:bg-red-400'
                   : quota.remaining < quota.total * 0.2
-                    ? 'bg-amber-500'
-                    : 'bg-blue-500'
+                    ? 'bg-amber-500 dark:bg-amber-400'
+                    : 'bg-blue-500 dark:bg-blue-400'
                   }`}
                 style={{
                   width: `${Math.min(100, ((quota.total - quota.remaining) / quota.total) * 100)}%`,

--- a/packages/app/src/pages/Conversation.tsx
+++ b/packages/app/src/pages/Conversation.tsx
@@ -1,13 +1,11 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useState, useRef, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { AsideButton } from '../components/conversation/AsideButton';
-import { AsidePanel } from '../components/conversation/AsidePanel';
 import { MessageInput } from '../components/conversation/MessageInput';
 import { MessageList } from '../components/conversation/MessageList';
 import { useConversationSocket } from '../hooks/useConversationSocket';
 import { MobileMessageInput } from '../components/conversation/MobileMessageInput';
-import { CoachInsightsPanel } from '../components/conversation/CoachInsightsPanel';
 import { ThemeToggle } from '../components/ThemeToggle';
+import Markdown from 'react-markdown';
 
 
 /** Full-screen centered message with optional title, message, and action button */
@@ -26,7 +24,7 @@ function FullScreenMessage({
     <div className="flex h-dvh items-center justify-center bg-gray-50 dark:bg-gray-900">
       <div className="text-center">
         {title && <h1 className={`text-2xl font-bold ${titleColor}`}>{title}</h1>}
-        {message && <div className="mt-2 text-gray-600 dark:text-gray-400">{message}</div>}
+        {message && <div className="mt-2 text-gray-600 dark:text-gray-400 text-xl">{message}</div>}
         {action && <div className="mt-4">{action}</div>}
       </div>
     </div>
@@ -61,11 +59,25 @@ export function Conversation() {
   return <ConversationContent sessionId={parsedSessionId} />;
 }
 
+// Markdown styling for coach messages - matches main conversation
+const markdownClasses = `
+  [&_p]:my-3 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_p]:text-lg [&_p]:leading-relaxed
+  [&_strong]:font-semibold
+  [&_em]:italic
+  [&_ul]:list-disc [&_ul]:ml-5 [&_ul]:my-3 [&_ul]:text-lg
+  [&_ol]:list-decimal [&_ol]:ml-5 [&_ol]:my-3 [&_ol]:text-lg
+  [&_li]:my-2 [&_li]:text-lg
+  [&_code]:bg-black/10 dark:bg-white/10 [&_code]:px-1.5 [&_code]:rounded [&_code]:text-base
+  [&_pre]:bg-black/10 dark:bg-white/10 [&_pre]:p-3 [&_pre]:rounded [&_pre]:overflow-x-auto [&_pre]:my-3 [&_pre]:text-base
+  [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:my-3 [&_blockquote]:text-lg
+  [&_hr]:my-4 [&_hr]:border-current [&_hr]:opacity-30
+`.trim();
+
 function ConversationContent({ sessionId }: { sessionId: number }) {
   const navigate = useNavigate();
-  const [asideOpen, setAsideOpen] = useState(false);
-  const [mobileInsightsOpen, setMobileInsightsOpen] = useState(false);
   const [isInputFocused, setIsInputFocused] = useState(false);
+  const coachMessagesEndRef = useRef<HTMLDivElement>(null);
+  const coachInputRef = useRef<HTMLTextAreaElement>(null);
 
   const {
     status,
@@ -88,17 +100,12 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
     navigate('/');
   };
 
-  const handleAsideOpen = () => {
-    setAsideOpen(true);
-  };
-
-  const handleAsideClose = () => {
-    setAsideOpen(false);
-  };
-
-  const handleAsideSend = (question: string) => {
-    startAside(question);
-  };
+  // Auto-scroll coach messages
+  useEffect(() => {
+    if (coachMessagesEndRef.current) {
+      coachMessagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [asideMessages]);
 
   // Loading state
   if (status === 'connecting' && !scenario) {
@@ -139,7 +146,7 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
     if (isStreaming) {
       if (streamingRole === 'partner') return 'Partner is typing...';
       if (streamingRole === 'coach') return 'Coach is thinking...';
-      return 'Processing...'; // Fallback for transient state
+      return 'Processing...';
     }
     if (status === 'connecting') {
       return 'Reconnecting...';
@@ -152,12 +159,26 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
   // Filter out aside messages from the main conversation view
   const mainMessages = messages.filter(m => !('asideThreadId' in m));
 
-  return (
+  const handleCoachSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (coachInputRef.current && coachInputRef.current.value.trim() && !isAsideStreaming) {
+      startAside(coachInputRef.current.value.trim());
+      coachInputRef.current.value = '';
+    }
+  };
 
+  const handleCoachKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleCoachSubmit(e);
+    }
+  };
+
+  return (
     <div className="flex h-dvh flex-col bg-gray-50 dark:bg-gray-900">
       {/* Header */}
       <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-3">
-        <div className="mx-auto flex max-w-6xl items-center justify-between">
+        <div className="mx-auto flex max-w-7xl items-center justify-between">
           <div>
             <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
               {scenario?.name || 'Conversation'}
@@ -179,113 +200,164 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
         </div>
       </header>
 
-      {/* Messages area - WIDER max-width */}
-      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col overflow-hidden">
-        {/* Render ONLY main messages (not aside messages) */}
-        <MessageList
-          messages={mainMessages}
-          isStreaming={isStreaming}
-        />
-
-        {/* Status indicator */}
-        {statusText && (
-          <div className="px-4 py-2 text-center text-base text-gray-500 dark:text-gray-400">{statusText}</div>
-        )}
-
-        {/* Quota warning */}
-        {quota && !quota.exhausted && quota.remaining < quota.total * 0.2 && (
-          <div className="bg-amber-50 dark:bg-amber-900/30 px-4 py-2 text-center text-base text-amber-700 dark:text-amber-300">
-            Low quota: {quota.remaining.toLocaleString()} / {quota.total.toLocaleString()} tokens
-            remaining
-          </div>
-        )}
-
-        {/* Quota exhausted */}
-        {quota?.exhausted && (
-          <div className="bg-red-50 dark:bg-red-900/30 px-4 py-2 text-center text-base text-red-700 dark:text-red-300">
-            Quota exhausted. You can no longer send messages.
-          </div>
-        )}
-
-        {/* Recoverable error */}
-        {error?.recoverable && (
-          <div className="bg-red-50 dark:bg-red-900/30 px-4 py-2 text-center text-base text-red-700 dark:text-red-300">
-            {error.message}
-          </div>
-        )}
-
-        {/* Desktop Input with Ask Coach button */}
-        <div className="relative hidden md:block">
-
-          <MessageInput
-            onSend={sendMessage}
-            disabled={isStreaming || quota?.exhausted || false}
-            placeholder={quota?.exhausted ? 'Quota exhausted' : undefined}
-          />
-          {/* Ask Coach button positioned above the input (Desktop) */}
-          <div className="absolute right-4 -top-12 hidden md:block">
-            <AsideButton
-              onClick={handleAsideOpen}
-              disabled={isStreaming || quota?.exhausted || false}
+      {/* SPLIT SCREEN LAYOUT - Centered together with margins */}
+      <div className="flex-1 flex overflow-hidden justify-center px-8">
+        
+        {/* LEFT SIDE: Main Conversation */}
+        <div className="flex w-full max-w-4xl flex-col">
+          <div className="flex w-full flex-1 flex-col overflow-hidden">
+            
+            {/* Main conversation messages */}
+            <MessageList
+              messages={mainMessages}
+              isStreaming={isStreaming}
             />
+
+            {/* Status indicator */}
+            {statusText && (
+              <div className="px-4 py-2 text-center text-base text-gray-500 dark:text-gray-400">{statusText}</div>
+            )}
+
+            {/* Quota warning */}
+            {quota && !quota.exhausted && quota.remaining < quota.total * 0.2 && (
+              <div className="bg-amber-50 dark:bg-amber-900/30 px-4 py-2 text-center text-base text-amber-700 dark:text-amber-300">
+                Low quota: {quota.remaining.toLocaleString()} / {quota.total.toLocaleString()} tokens remaining
+              </div>
+            )}
+
+            {/* Quota exhausted */}
+            {quota?.exhausted && (
+              <div className="bg-red-50 dark:bg-red-900/30 px-4 py-2 text-center text-base text-red-700 dark:text-red-300">
+                Quota exhausted. You can no longer send messages.
+              </div>
+            )}
+
+            {/* Recoverable error */}
+            {error?.recoverable && (
+              <div className="bg-red-50 dark:bg-red-900/30 px-4 py-2 text-center text-base text-red-700 dark:text-red-300">
+                {error.message}
+              </div>
+            )}
+
+            {/* Desktop Input */}
+            <div className="hidden md:block">
+              <MessageInput
+                onSend={sendMessage}
+                disabled={isStreaming || quota?.exhausted || false}
+                placeholder={quota?.exhausted ? 'Quota exhausted' : 'Type your message...'}
+              />
+            </div>
+
+            {/* Mobile Input */}
+            <div className="md:hidden">
+              <MobileMessageInput
+                onSendPartner={sendMessage}
+                onSendCoach={startAside}
+                partnerName={scenario?.partnerPersona || 'Partner'}
+                disabled={isStreaming || isAsideStreaming || quota?.exhausted || false}
+                isInsightsOpen={false}
+                onToggleInsights={() => {}}
+                onInputFocus={() => setIsInputFocused(true)}
+                onInputBlur={() => setIsInputFocused(false)}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT SIDE: Coach Panel - Rounded on BOTH sides */}
+        <div className="hidden md:flex md:w-[32rem] lg:w-[36rem] flex-col bg-white dark:bg-gray-800 border-l-2 border-r-2 border-gray-300 dark:border-gray-600 rounded-2xl shadow-lg overflow-hidden">
+          
+          {/* Coach header */}
+          <div className="border-b border-gray-200 dark:border-gray-700 bg-yellow-50 dark:bg-yellow-900/20 px-5 py-4">
+            <h2 className="text-xl font-semibold text-yellow-900 dark:text-yellow-200 flex items-center gap-2">
+              💡 Coach
+            </h2>
+            <p className="text-base text-yellow-800 dark:text-yellow-300 mt-1">
+              Ask for advice anytime
+            </p>
           </div>
 
-          {/* Mobile Ask Coach Slide-up Trigger */}
-          <button
-            type="button"
-            onClick={handleAsideOpen}
-            disabled={isStreaming || quota?.exhausted || false}
-            className="absolute left-1/2 -top-10 -translate-x-1/2 flex items-center justify-center h-8 w-12 rounded-t-lg bg-amber-500 dark:bg-amber-600 text-white shadow-lg md:hidden hover:bg-amber-600 dark:hover:bg-amber-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
-            aria-label="Ask Coach"
+          {/* Coach messages */}
+          <div className="flex-1 overflow-y-auto p-5 space-y-4">
+            {asideMessages.length === 0 && !isAsideStreaming ? (
+              <div className="text-center text-gray-500 dark:text-gray-400 text-base py-8">
+                <p className="mb-2 text-lg">👋 Hi! I'm your conversation coach.</p>
+                <p className="text-base">
+                  I can see your full conversation and provide guidance. Ask me anything!
+                </p>
+              </div>
+            ) : (
+              asideMessages.map((msg, i) => (
+                <div key={msg.id !== -1 ? msg.id : `streaming-${i}`}>
+                  {msg.role === 'user' ? (
+                    // User message - matches main conversation style
+                    <div className="flex justify-end">
+                      <div className="max-w-[85%] rounded-2xl px-6 py-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-lg">
+                        {msg.content}
+                      </div>
+                    </div>
+                  ) : (
+                    // Coach message - matches YELLOW coach messages from main conversation
+                    <div className="flex justify-start">
+                      <div className={`max-w-[85%] rounded-2xl px-6 py-4 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-900 dark:text-yellow-100 border border-yellow-200 dark:border-yellow-700 ${markdownClasses}`}>
+                        <Markdown>{msg.content}</Markdown>
+                        {msg.isStreaming && <span className="ml-1 animate-pulse text-lg">|</span>}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))
+            )}
+            <div ref={coachMessagesEndRef} />
+          </div>
+
+          {/* Coach error */}
+          {asideError && (
+            <div className="px-4 py-2 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-sm border-t border-red-200 dark:border-red-800">
+              {asideError.message}
+            </div>
+          )}
+
+          {/* Coach input */}
+          <form 
+            onSubmit={handleCoachSubmit}
+            className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2.5}
-              stroke="currentColor"
-              className="h-5 w-5"
-            >
-              <title>Ask Coach</title>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-            </svg>
-          </button>
+            <div className="flex gap-3 items-end">
+              <textarea
+                ref={coachInputRef}
+                placeholder="Ask the coach a question..."
+                disabled={isAsideStreaming}
+                rows={1}
+                onKeyDown={handleCoachKeyDown}
+                className="flex-1 resize-none rounded-3xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-5 py-3 text-lg focus:border-yellow-500 dark:focus:border-yellow-400 focus:outline-none focus:ring-2 focus:ring-yellow-500 dark:focus:ring-yellow-400 disabled:bg-gray-100 dark:disabled:bg-gray-800"
+              />
+              {isAsideStreaming ? (
+                <button
+                  type="button"
+                  onClick={cancelAside}
+                  className="rounded-2xl bg-red-500 dark:bg-red-600 px-6 py-3 text-white hover:bg-red-600 dark:hover:bg-red-700 text-base font-medium"
+                >
+                  Cancel
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  disabled={!coachInputRef.current?.value.trim()}
+                  className="rounded-2xl bg-yellow-500 dark:bg-yellow-600 px-6 py-3 text-white hover:bg-yellow-600 dark:hover:bg-yellow-700 text-base font-medium disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:cursor-not-allowed"
+                >
+                  Ask
+                </button>
+              )}
+            </div>
+          </form>
         </div>
-
-        {/* Mobile Input */}
-        <div className="md:hidden">
-          <MobileMessageInput
-            onSendPartner={sendMessage}
-            onSendCoach={(content) => {
-              handleAsideSend(content);
-              setMobileInsightsOpen(true);
-            }}
-            partnerName={scenario?.partnerPersona || 'Partner'}
-            disabled={isStreaming || isAsideStreaming || quota?.exhausted || false}
-            isInsightsOpen={mobileInsightsOpen}
-            onToggleInsights={() => setMobileInsightsOpen(!mobileInsightsOpen)}
-            onInputFocus={() => setIsInputFocused(true)}
-            onInputBlur={() => setIsInputFocused(false)}
-          />
-
-        </div>
-
-        {/* Mobile Coach Insights Panel */}
-        {/* Only show when input is NOT focused (keyboard is closed) */}
-        {!isInputFocused && (
-          <CoachInsightsPanel
-            isOpen={mobileInsightsOpen}
-            onClose={() => setMobileInsightsOpen(false)}
-            messages={asideMessages}
-          />
-        )}
       </div>
 
-      {/* Quota bar at bottom */}
+      {/* Quota bar at bottom - full width */}
       {quota && (
         <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2 hidden md:block">
-
-          <div className="mx-auto max-w-6xl">
+          <div className="mx-auto max-w-7xl">
             <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
               <span>Token usage</span>
               <span>
@@ -294,12 +366,13 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
             </div>
             <div className="mt-1 h-1.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
               <div
-                className={`h-1.5 rounded-full transition-all ${quota.exhausted
-                  ? 'bg-red-500 dark:bg-red-400'
-                  : quota.remaining < quota.total * 0.2
+                className={`h-1.5 rounded-full transition-all ${
+                  quota.exhausted
+                    ? 'bg-red-500 dark:bg-red-400'
+                    : quota.remaining < quota.total * 0.2
                     ? 'bg-amber-500 dark:bg-amber-400'
                     : 'bg-blue-500 dark:bg-blue-400'
-                  }`}
+                }`}
                 style={{
                   width: `${Math.min(100, ((quota.total - quota.remaining) / quota.total) * 100)}%`,
                 }}
@@ -308,17 +381,6 @@ function ConversationContent({ sessionId }: { sessionId: number }) {
           </div>
         </div>
       )}
-
-      {/* Aside Panel */}
-      <AsidePanel
-        isOpen={asideOpen}
-        onClose={handleAsideClose}
-        messages={asideMessages}
-        isStreaming={isAsideStreaming}
-        error={asideError}
-        onSend={handleAsideSend}
-        onCancel={cancelAside}
-      />
     </div>
   );
 }

--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -16,7 +16,7 @@ export function Home() {
       <YourSessions />
       {isStaffOrAdmin && (
         <>
-          <h2 className="mb-6 text-lg font-medium text-gray-900">Start a new conversation</h2>
+          <h2 className="mb-6 text-lg font-medium text-gray-900 dark:text-white">Start a new conversation</h2>
           <ScenarioList />
         </>
       )}

--- a/packages/app/tailwind.config.js
+++ b/packages/app/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
-  Coach panel always visible on right side (desktop only)
-  Split-screen layout with centered panels
-  shadow separation (no border lines)
-  Enter key to send coach messages
-  Improved dark mode readability for coach header
-  Coach messages match main conversation styling
-  Auto-scroll coach messages
-  Mobile unchanged 