### PR TITLE
Add web search grounding for partner (Gemini) and coach (Claude)

### DIFF
--- a/packages/api/src/llm/providers/anthropic.ts
+++ b/packages/api/src/llm/providers/anthropic.ts
@@ -19,6 +19,10 @@ export const anthropicProvider: LLMProvider = {
 
   async *streamCompletion(params: StreamParams): AsyncIterable<StreamChunk> {
     try {
+      const tools = params.useWebSearch
+        ? ([{ type: 'web_search_20250305', name: 'web_search' }] as const)
+        : undefined;
+
       const stream = getClient().messages.stream({
         model: params.model,
         system: params.systemPrompt,
@@ -27,6 +31,7 @@ export const anthropicProvider: LLMProvider = {
           content: m.content.trim(), // Trim to avoid "trailing whitespace" error
         })),
         max_tokens: params.maxTokens ?? 1024,
+        ...(tools ? { tools } : {}),
       });
 
       // Wire up abort signal to cancel the stream

--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -18,8 +18,8 @@ import { type HistoryMessage, type ScenarioInfo, send } from './protocol.js';
 
 // Default models for custom scenarios
 const DEFAULT_PARTNER_MODEL = 'google:gemini-2.0-flash';
-const DEFAULT_COACH_MODEL = 'claude-3-5-sonnet-20241022';
-const FALLBACK_PARTNER_MODEL = 'claude-3-5-sonnet-20241022';
+const DEFAULT_COACH_MODEL = 'claude-sonnet-4-20250514';
+const FALLBACK_PARTNER_MODEL = 'claude-sonnet-4-20250514';
 
 const ASIDE_INSTRUCTIONS = `
 When responding to an aside question (marked with [ASIDE QUESTION]):
@@ -216,18 +216,21 @@ export class ConversationManager {
         }
 
         const context = this.buildContext(role);
-        return await this.tryStreamWithFallback(role, modelString, systemPrompt, context);
+        const useWebSearch = role === 'partner'
+            ? (this.session.scenario?.partnerUseWebSearch ?? false)
+            : (this.session.scenario?.coachUseWebSearch ?? false);
+        return await this.tryStreamWithFallback(role, modelString, systemPrompt, context, useWebSearch);
     }
 
     private async tryStreamWithFallback(
         role: 'partner' | 'coach',
         modelString: string,
         systemPrompt: string,
-        context: LLMMessage[]
+        context: LLMMessage[],
+        useWebSearch = false
     ): Promise<{ content: string; messageId: number; usage: TokenUsage } | null> {
         const isGeminiModel = modelString.startsWith('google:') || modelString.includes('gemini');
         let currentModel = modelString;
-        let useWebSearch = role === 'partner' && isGeminiModel;
         let usedFallback = false;
 
         for (let attempt = 0; attempt < 2; attempt++) {
@@ -284,6 +287,7 @@ export class ConversationManager {
                     return { content: fullContent, messageId: message.id, usage };
                 } catch (error) {
                     const errorMsg = error instanceof Error ? error.message : String(error);
+                    this.logger.error({ sessionId: this.session.id, role, model: currentModel, errorMsg }, 'Provider error in tryStreamWithFallback');
                     if (isGeminiModel && (errorMsg.includes('429') || errorMsg.includes('quota')) && !usedFallback) {
                         currentModel = FALLBACK_PARTNER_MODEL;
                         useWebSearch = false;

--- a/packages/database/prisma/migrations/20260311000000_add_coach_web_search/migration.sql
+++ b/packages/database/prisma/migrations/20260311000000_add_coach_web_search/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Scenario" ADD COLUMN "coachUseWebSearch" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -137,6 +137,7 @@ model Scenario {
   partnerModel        String  @default("claude-sonnet-4-20250514")
   coachModel          String  @default("claude-sonnet-4-20250514")
   partnerUseWebSearch Boolean @default(false)
+  coachUseWebSearch   Boolean @default(false)
 
   isActive  Boolean  @default(true)
   createdAt DateTime @default(now())

--- a/packages/database/seed/seedDatabase.ts
+++ b/packages/database/seed/seedDatabase.ts
@@ -39,6 +39,9 @@ const SCENARIOS = [
   {
     name: 'Angry Uncle at Thanksgiving',
     slug: 'angry-uncle-thanksgiving',
+    partnerModel: 'google:gemini-2.0-flash',
+    partnerUseWebSearch: true,
+    coachUseWebSearch: true,
     description:
       'Practice navigating political disagreements with a family member during a holiday dinner.',
     partnerPersona: 'Your uncle who has strong political opinions',
@@ -49,17 +52,21 @@ Keep your responses conversational - 2-4 sentences typically, like a real back-a
 Start the conversation with a provocative political statement about current events.`,
     coachSystemPrompt: `You are a conversation coach helping the user practice constructive dialogue across political differences. Guide them through this framework:
 
-**LISTEN** - Encourage the user to truly hear what their uncle is saying before responding. Prompt them to ask clarifying questions.
+**LISTEN** - Encourage the user to truly hear what their uncle is saying before responding. They should be ready to summarize or paraphrase — not just the viewpoint, but the underlying values and concerns behind it. Prompt them to look for something they can agree with, even partially. Remind them to turn off their inner debater and not prepare a rebuttal yet.
 
-**ACKNOWLEDGE** - Help the user validate their uncle's feelings and concerns without necessarily agreeing with his conclusions. ("It sounds like you're frustrated about...")
+**ACKNOWLEDGE** - Help the user feed back what they heard — the viewpoint AND the feelings, values, and concerns behind it — in their own words (not just parroting). They can add a brief genuine agreement if there is one ("I agree the system is broken"). Examples: "I hear that you're worried about X" or "It sounds like what really matters to you is Y."
 
-**ASK ABOUT PERSONAL EXPERIENCE (optional)** - When appropriate, suggest the user ask what's behind the uncle's strong opinions. What has he personally experienced? This can build understanding and humanize the conversation, but isn't always necessary.
+**ASK ABOUT PERSONAL EXPERIENCE (optional)** - When appropriate, suggest the user ask what's behind the uncle's strong opinions. What has he personally experienced? This helps surface deeper values and humanize the conversation, but skip it if the conversation is already flowing well or the uncle seems impatient.
 
-**FIND COMMON GROUND** - Point out shared values or concerns that both might agree on (e.g., wanting families to thrive, fairness, security).
+**FIND COMMON GROUND (optional)** - If a natural opportunity arises, help the user identify shared values or concerns that both sides might genuinely agree on (e.g., wanting families to be safe, fairness, community). This can create a useful foundation before sharing their own view, but don't force it if it feels artificial.
 
-**PIVOT** - Once rapport is built, help the user gently introduce their own perspective, connected to the common ground.
+**PIVOT** - Help the user signal that they'd like to share their own perspective — but the pivot is just the signal, not the perspective itself. Examples: "Can I offer a different way of looking at this?" or "May I share how I see it?" Crucially: the user should wait for a verbal or nonverbal signal that the uncle is ready to listen. If he repeats his point or seems closed off, coach the user to loop back and repeat LAPP before pivoting again.
 
-**PRESENT** - Guide the user to share their view using "I" statements and personal experience, not confrontation.
+**PRESENT** - Guide the user to share their view using:
+- **I-statements** rather than truth claims ("This is how I see it" not "This is just how it is")
+- **Name their sources** when relevant ("I'm basing this on...")
+- **A personal story or experience** if they have one — it's more persuasive than abstract arguments
+- **Mention something they agree with** to keep the connection alive
 
 Throughout, remind the user to maintain a calm, curious, and respectful tone. The goal is understanding, not winning.
 
@@ -68,6 +75,9 @@ Be concise and actionable. Focus on what to do next, not lengthy explanations.`,
   {
     name: 'Difficult Coworker Feedback',
     slug: 'difficult-coworker',
+    partnerModel: 'google:gemini-2.0-flash',
+    partnerUseWebSearch: true,
+    coachUseWebSearch: true,
     description:
       'Practice giving constructive feedback to a defensive coworker about missed deadlines.',
     partnerPersona: 'A coworker who becomes defensive when receiving feedback',


### PR DESCRIPTION
- Add coachUseWebSearch field to Scenario schema with migration
- Wire partnerUseWebSearch and coachUseWebSearch from DB into stream params instead of inferring from model name
- Enable Anthropic web_search_20250305 tool when useWebSearch is true
- Update both built-in scenarios to use Gemini for partner + web search enabled
- Fix stale claude-3-5-sonnet-20241022 model IDs (404) → claude-sonnet-4-20250514