### PR TITLE
fix: resolve Docker build failures and local dev env loading

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+**/node_modules/
 .pnpm-store/
 
 # Git

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 # Install system dependencies (OpenSSL for Prisma)
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm (pinned to match pnpm-lock.yaml version)
+RUN npm install -g pnpm@10.28.2
 
 # Copy workspace config and all package sources (needed for proper workspace linking)
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./

--- a/packages/api/src/load-env.ts
+++ b/packages/api/src/load-env.ts
@@ -1,0 +1,6 @@
+import { config } from 'dotenv';
+import { resolve } from 'node:path';
+
+// Load .env from the repo root for local development.
+// No-op if the file doesn't exist (Docker sets env vars via compose environment:).
+config({ path: resolve(process.cwd(), '../../.env') });

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,3 +1,4 @@
+import './load-env.js';
 import * as Sentry from '@sentry/node';
 
 // Sentry must be initialized before anything else

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -2,8 +2,8 @@ FROM node:22-slim
 
 WORKDIR /app
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm (pinned to match pnpm-lock.yaml version)
+RUN npm install -g pnpm@10.28.2
 
 # Copy workspace files
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
@@ -16,9 +16,6 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY packages/database ./packages/database
 COPY packages/app ./packages/app
-
-# Generate Prisma Client
-RUN pnpm -F @workspace/database generate
 
 # Expose port
 EXPOSE 5173

--- a/packages/app/src/components/conversation/LappMetricsPanel.tsx
+++ b/packages/app/src/components/conversation/LappMetricsPanel.tsx
@@ -122,7 +122,12 @@ function LappRadar({ l, a, p, pe }: { l: number; a: number; p: number; pe: numbe
   });
 
   return (
-    <svg viewBox="0 0 104 104" className="w-full h-full" role="img" aria-labelledby="lapp-radar-title">
+    <svg
+      viewBox="0 0 104 104"
+      className="w-full h-full"
+      role="img"
+      aria-labelledby="lapp-radar-title"
+    >
       <title id="lapp-radar-title">LAPP skill radar</title>
       {/* Grid diamonds */}
       {gridRings.map((pts) => (


### PR DESCRIPTION
- Add **/node_modules/ to .dockerignore so Windows-host symlinks (pointing to C:/Users/... paths) are not copied into Linux containers, which caused vite to be unresolvable in the app container
- Pin pnpm to 10.28.2 in both Dockerfiles to match pnpm-lock.yaml and avoid breaking changes from unpinned latest pnpm
- Remove unnecessary `pnpm -F @workspace/database generate` step from app Dockerfile — the app package imports nothing from @workspace/database
- Add packages/api/src/load-env.ts and import it as the first module in server.ts so DATABASE_URL is set before @workspace/database (which creates the Prisma singleton at module evaluation time) is imported; fixes local `pnpm dev` without Docker