### PR TITLE
feat: emit conversation lifecycle telemetry events

### DIFF
--- a/packages/api/src/trpc/routers/invitation.ts
+++ b/packages/api/src/trpc/routers/invitation.ts
@@ -246,6 +246,18 @@ export const invitationRouter = router({
             },
           });
           sessionId = newSession.id;
+          await track(
+            ctx.prisma,
+            TelemetryEvents.CONVERSATION_STARTED,
+            {
+              scenarioId: invitation.scenarioId,
+              scenarioSlug: invitation.scenario?.slug,
+              isCustom: false,
+              source: 'invitation',
+              invitationId: invitation.id,
+            },
+            { userId, sessionId }
+          );
         }
       } else {
         // Create new session for first-time claim
@@ -273,6 +285,18 @@ export const invitationRouter = router({
           },
         });
         sessionId = newSession.id;
+        await track(
+          ctx.prisma,
+          TelemetryEvents.CONVERSATION_STARTED,
+          {
+            scenarioId: invitation.scenarioId ?? null,
+            scenarioSlug: invitation.scenario?.slug ?? (elaborationResult ? 'custom' : null),
+            isCustom: !!elaborationResult,
+            source: 'invitation',
+            invitationId: invitation.id,
+          },
+          { userId, sessionId }
+        );
       }
 
       // Get user info

--- a/packages/api/src/trpc/routers/session.ts
+++ b/packages/api/src/trpc/routers/session.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { parseQuota } from '../../lib/quota.js';
+import { TelemetryEvents, track } from '../../lib/telemetry.js';
 import { generateToken } from '../../lib/tokens.js';
 import { protectedProcedure, publicProcedure, router } from '../procedures.js';
 
@@ -51,7 +52,7 @@ export const sessionRouter = router({
       if (input.scenarioId) {
         const scenario = await ctx.prisma.scenario.findUnique({
           where: { id: input.scenarioId },
-          select: { id: true, name: true },
+          select: { id: true, name: true, slug: true },
         });
 
         if (!scenario) {
@@ -81,6 +82,18 @@ export const sessionRouter = router({
             },
           });
         });
+
+        await track(
+          ctx.prisma,
+          TelemetryEvents.CONVERSATION_STARTED,
+          {
+            scenarioId: scenario.id,
+            scenarioSlug: scenario.slug,
+            isCustom: false,
+            source: 'staff_quickstart',
+          },
+          { userId: ctx.user.id, sessionId: session.id }
+        );
 
         return { sessionId: session.id };
       }
@@ -121,6 +134,17 @@ export const sessionRouter = router({
           },
         });
       });
+
+      await track(
+        ctx.prisma,
+        TelemetryEvents.CONVERSATION_STARTED,
+        {
+          scenarioSlug: 'custom',
+          isCustom: true,
+          source: 'staff_quickstart',
+        },
+        { userId: ctx.user.id, sessionId: session.id }
+      );
 
       return { sessionId: session.id };
     }),

--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -14,6 +14,7 @@ import type { WebSocket } from 'ws';
 const DEFAULT_MODEL = 'gpt-4o';
 
 import { getInvitationQuotaStatus, type Quota } from '../lib/quota.js';
+import { TelemetryEvents, track } from '../lib/telemetry.js';
 import { streamCompletion } from '../llm/registry.js';
 import type { LLMMessage, TokenUsage } from '../llm/types.js';
 import { broadcast } from './broadcaster.js';
@@ -167,6 +168,14 @@ export class ConversationManager {
       const userMsg = await this.persistMessage('user', content);
       this.session.messages.push(userMsg);
 
+      const turnNumber = this.session.messages.filter((m) => m.role === 'user').length;
+      await track(
+        this.prisma,
+        TelemetryEvents.MESSAGE_SENT,
+        { length: content.length, turnNumber },
+        { userId: this.session.userId ?? undefined, sessionId: this.session.id }
+      );
+
       broadcast(this.session.id, {
         type: 'history',
         messages: [
@@ -210,7 +219,6 @@ export class ConversationManager {
         });
 
         // Fire-and-forget LAPP scorer (does not block the next exchange)
-        const turnNumber = this.session.messages.filter((m) => m.role === 'user').length;
         this.runLappScorer(userMsg.id, content, partnerResult.content, turnNumber).catch(() => {});
       }
     } catch (error) {
@@ -424,6 +432,20 @@ export class ConversationManager {
           };
           send(this.ws, doneMsg);
           broadcast(this.session.id, doneMsg);
+
+          await track(
+            this.prisma,
+            TelemetryEvents.STREAM_COMPLETED,
+            {
+              role,
+              model: currentModel,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              contentLength: fullContent.trim().length,
+              usedFallback,
+            },
+            { userId: this.session.userId ?? undefined, sessionId: this.session.id }
+          );
 
           return { content: fullContent, messageId: message.id, usage };
         } catch (error) {
@@ -704,6 +726,34 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
     }
   }
 
+  async onClose(reason: 'idle_timeout' | 'disconnect'): Promise<void> {
+    // Idempotent: only the first close transitions the session to ended.
+    const now = new Date();
+    const durationMs = now.getTime() - this.session.startedAt.getTime();
+    const result = await this.prisma.conversationSession.updateMany({
+      where: { id: this.session.id, endedAt: null },
+      data: {
+        endedAt: now,
+        durationSeconds: Math.round(durationMs / 1000),
+        status: 'COMPLETED',
+      },
+    });
+    if (result.count === 0) return;
+
+    await track(
+      this.prisma,
+      TelemetryEvents.CONVERSATION_ENDED,
+      {
+        reason,
+        durationMs,
+        totalMessages: this.session.messages.length,
+        scenarioSlug:
+          this.session.scenario?.slug ?? (this.session.customPartnerPersona ? 'custom' : null),
+      },
+      { userId: this.session.userId ?? undefined, sessionId: this.session.id }
+    );
+  }
+
   async handleAsideStart(threadId: string, question: string): Promise<void> {
     if (this.isProcessing || this.activeAsideThreadId) {
       send(this.ws, { type: 'aside:error', threadId, error: 'Response in progress' });
@@ -838,6 +888,20 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
       });
       this.session.messages.push(message);
       send(this.ws, { type: 'aside:done', threadId, messageId: message.id, usage });
+
+      await track(
+        this.prisma,
+        TelemetryEvents.STREAM_COMPLETED,
+        {
+          role: 'aside',
+          model: modelString,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          contentLength: fullContent.trim().length,
+        },
+        { userId: this.session.userId ?? undefined, sessionId: this.session.id }
+      );
+
       return { content: fullContent, messageId: message.id, usage };
     } catch (error) {
       this.logger.error({ sessionId: this.session.id, threadId, error }, 'Aside stream error');

--- a/packages/api/src/ws/handler.ts
+++ b/packages/api/src/ws/handler.ts
@@ -92,13 +92,16 @@ export async function registerWebSocketHandler(fastify: FastifyInstance): Promis
       await manager.initialize();
 
       // Set up idle timeout
+      let wasIdleTimeout = false;
       let idleTimer = setTimeout(() => {
+        wasIdleTimeout = true;
         socket.close(1000, 'Idle timeout');
       }, IDLE_TIMEOUT_MS);
 
       const resetIdleTimer = () => {
         clearTimeout(idleTimer);
         idleTimer = setTimeout(() => {
+          wasIdleTimeout = true;
           socket.close(1000, 'Idle timeout');
         }, IDLE_TIMEOUT_MS);
       };
@@ -178,6 +181,9 @@ export async function registerWebSocketHandler(fastify: FastifyInstance): Promis
 
       socket.on('close', () => {
         clearTimeout(idleTimer);
+        manager.onClose(wasIdleTimeout ? 'idle_timeout' : 'disconnect').catch((err) => {
+          fastify.log.error({ sessionId, err }, 'Failed to record session close');
+        });
         fastify.log.info({ sessionId }, 'WebSocket closed');
       });
 


### PR DESCRIPTION
## Summary

The admin telemetry dashboard reads `conversation_started`, `message_sent`, `stream_completed`, and `conversation_ended` events, but only `user_authenticated` was actually being emitted — conversations left no trace on the page.

This wires up the four missing events:

- **`conversation_started`** — fires on session creation in `session.startNew` (both predefined and custom scenario paths) and `invitation.claim` (both first-time-claim branches). Carries `scenarioSlug` (so the top-scenarios chart works), plus `isCustom` and `source` (`invitation` vs `staff_quickstart`).
- **`message_sent`** — fires after the user's message is persisted in `ConversationManager.handleUserMessage`. Carries `length` and `turnNumber`.
- **`stream_completed`** — fires for partner, coach, and aside streams. Carries `inputTokens`/`outputTokens` so the dashboard's Tokens card adds up.
- **`conversation_ended`** — new `ConversationManager.onClose(reason)` method called from the WebSocket close handler. Idempotent via `updateMany({ where: { id, endedAt: null } })` so reconnects don't fire duplicates. Transitions the session to `COMPLETED` and records `endedAt` + `durationSeconds`.

## Notes

- The dashboard's completion-rate card looks for `reason === 'completed'` on `conversation_ended`. Right now nothing emits that — sessions can always be resumed, so every close is `idle_timeout` or `disconnect`. Mapping quota exhaustion to `'completed'` will be a separate PR.
- Pre-existing typecheck errors for missing `@sentry/node` and `@google/genai` modules are unchanged by this PR.

## Test plan

- [ ] Start a conversation from the staff quick-start; confirm `conversation_started` appears on the telemetry page with the right `scenarioSlug`
- [ ] Send a message; confirm `message_sent` and `stream_completed` (partner) appear
- [ ] Send a second message; confirm a second `stream_completed` (coach) appears
- [ ] Close the tab / wait for idle timeout; confirm one `conversation_ended` with the right `reason`, and the session row in the DB has `endedAt` + `durationSeconds` + `status=COMPLETED`
- [ ] Reconnect to the same session and disconnect again; confirm no duplicate `conversation_ended`
- [ ] Open an invitation link, claim, start a session; confirm `conversation_started` carries `source: 'invitation'`
- [ ] Open the aside (coach Q&A) and confirm `stream_completed` fires with `role: 'aside'` and tokens add to the Tokens card

🤖 Generated with [Claude Code](https://claude.com/claude-code)