### PR TITLE
feat: mark conversation completed when quota is exhausted

### DIFF
--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -161,6 +161,7 @@ export class ConversationManager {
         const hasQuota = await this.checkQuotaAllowed();
         if (!hasQuota) {
           send(this.ws, { type: 'quota:exhausted' });
+          await this.onClose('completed');
           return;
         }
       }
@@ -717,6 +718,7 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
     const status = await getInvitationQuotaStatus(this.prisma, invitation.id, quota);
     if (!status.allowed) {
       send(this.ws, { type: 'quota:exhausted' });
+      await this.onClose('completed');
     } else if (status.remaining < quota.tokens * 0.2) {
       send(this.ws, {
         type: 'quota:warning',
@@ -726,7 +728,7 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
     }
   }
 
-  async onClose(reason: 'idle_timeout' | 'disconnect'): Promise<void> {
+  async onClose(reason: 'completed' | 'idle_timeout' | 'disconnect'): Promise<void> {
     // Idempotent: only the first close transitions the session to ended.
     const now = new Date();
     const durationMs = now.getTime() - this.session.startedAt.getTime();


### PR DESCRIPTION
## Summary

Stacks on #65. Wires the dashboard's completion-rate card to actually mean something.

Sessions in this app stay resumable — every WebSocket close in #65 fires `conversation_ended` with `reason: 'disconnect'` or `'idle_timeout'`. The one natural finish line is quota exhaustion: once tokens run out, the session can't be picked up again. This PR makes that the only path that emits `reason: 'completed'`.

Both quota-exhausted detection points now call `onClose('completed')`:
- `handleUserMessage` — pre-flight check before persisting the message
- `checkQuotaWarning` — post-stream check that catches the exchange that just exhausted the quota

`onClose` is idempotent via `endedAt`, so the eventual WebSocket close becomes a no-op.

## Test plan

- [ ] Start a session with a small quota (e.g., 200 tokens) and exchange messages until quota runs out
- [ ] Confirm one `conversation_ended` event is emitted with `reason: 'completed'`
- [ ] Confirm the dashboard's completion-rate card increments
- [ ] Confirm the session row has `status=COMPLETED`, `endedAt` set, `durationSeconds` set
- [ ] Close the WebSocket after quota exhaustion; confirm no duplicate `conversation_ended`
- [ ] In a separate session, disconnect normally without exhausting quota; confirm `reason: 'disconnect'` (not `'completed'`)

## Merge order

This PR's base is `feat/telemetry-conversation-events`. Once #65 lands on `main`, retarget this PR to `main` (it'll be a 3-line diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)