### PR TITLE
Add general feedback button with 5-star rating + admin view

### DIFF
--- a/packages/api/src/trpc/router.ts
+++ b/packages/api/src/trpc/router.ts
@@ -1,5 +1,6 @@
 import { router } from './procedures.js';
 import { authRouter } from './routers/auth.js';
+import { feedbackRouter } from './routers/feedback.js';
 import { invitationRouter } from './routers/invitation.js';
 import { observationRouter } from './routers/observation.js';
 import { scenarioRouter } from './routers/scenario.js';
@@ -9,6 +10,7 @@ import { userRouter } from './routers/user.js';
 
 export const appRouter = router({
   auth: authRouter,
+  feedback: feedbackRouter,
   invitation: invitationRouter,
   observation: observationRouter,
   scenario: scenarioRouter,

--- a/packages/api/src/trpc/routers/feedback.ts
+++ b/packages/api/src/trpc/routers/feedback.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import { adminProcedure, publicProcedure, router } from '../procedures.js';
+
+export const feedbackRouter = router({
+  /**
+   * Submit feedback. Open to all (anonymous + authenticated).
+   * If a user session exists, the feedback is associated with the user.
+   */
+  submit: publicProcedure
+    .input(
+      z.object({
+        rating: z.number().int().min(1).max(5),
+        comment: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const trimmed = input.comment?.trim();
+      await ctx.prisma.feedback.create({
+        data: {
+          rating: input.rating,
+          comment: trimmed && trimmed.length > 0 ? trimmed : null,
+          userId: ctx.userId ?? null,
+        },
+      });
+      return { success: true };
+    }),
+
+  /**
+   * List feedback entries for the admin dashboard.
+   */
+  list: adminProcedure
+    .input(
+      z
+        .object({
+          cursor: z.string().optional(),
+          limit: z.number().min(1).max(100).default(50),
+        })
+        .default({ limit: 50 })
+    )
+    .query(async ({ ctx, input }) => {
+      const { cursor, limit } = input;
+
+      const rows = await ctx.prisma.feedback.findMany({
+        include: {
+          user: {
+            select: { id: true, name: true, avatarUrl: true, role: true },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: limit + 1,
+        ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+      });
+
+      let nextCursor: string | undefined;
+      if (rows.length > limit) {
+        const next = rows.pop();
+        nextCursor = next?.id;
+      }
+
+      const items = rows.map((r) => ({
+        id: r.id,
+        rating: r.rating,
+        comment: r.comment,
+        createdAt: r.createdAt,
+        user: r.user,
+      }));
+
+      return { items, nextCursor };
+    }),
+
+  /**
+   * Aggregate stats for the admin dashboard header.
+   */
+  stats: adminProcedure.query(async ({ ctx }) => {
+    const [total, ratings] = await Promise.all([
+      ctx.prisma.feedback.count(),
+      ctx.prisma.feedback.findMany({ select: { rating: true } }),
+    ]);
+
+    const average =
+      ratings.length > 0 ? ratings.reduce((sum, r) => sum + r.rating, 0) / ratings.length : 0;
+
+    const distribution: Record<1 | 2 | 3 | 4 | 5, number> = {
+      1: 0,
+      2: 0,
+      3: 0,
+      4: 0,
+      5: 0,
+    };
+    for (const r of ratings) {
+      if (r.rating >= 1 && r.rating <= 5) {
+        distribution[r.rating as 1 | 2 | 3 | 4 | 5] += 1;
+      }
+    }
+
+    return { total, average, distribution };
+  }),
+});

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3,10 +3,12 @@ import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import type { AppRouter } from './api/trpc';
 import { TRPCProvider } from './api/trpc';
+import { FeedbackButton } from './components/FeedbackButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { UserMenu } from './components/UserMenu';
 import { AdminLayout } from './layouts/AdminLayout';
 import { ResearchLayout } from './layouts/ResearchLayout';
+import { Feedback } from './pages/admin/Feedback';
 import { Telemetry } from './pages/admin/Telemetry';
 import { UserDetail } from './pages/admin/UserDetail';
 import { UserList } from './pages/admin/UserList';
@@ -78,6 +80,7 @@ export function App() {
               <Route path="users" element={<UserList />} />
               <Route path="users/:id" element={<UserDetail />} />
               <Route path="telemetry" element={<Telemetry />} />
+              <Route path="feedback" element={<Feedback />} />
             </Route>
 
             {/* Research area with sidebar layout */}
@@ -133,6 +136,7 @@ export function App() {
                       <Route path="/invite/:token" element={<Invite />} />
                     </Routes>
                   </main>
+                  <FeedbackButton />
                 </div>
               }
             />

--- a/packages/app/src/components/AdminSidebar.tsx
+++ b/packages/app/src/components/AdminSidebar.tsx
@@ -41,6 +41,21 @@ const navItems: NavItem[] = [
       </svg>
     ),
   },
+  {
+    href: '/admin/feedback',
+    label: 'Feedback',
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <title>Feedback</title>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.075 10.1c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.521-4.673z"
+        />
+      </svg>
+    ),
+  },
 ];
 
 export function AdminSidebar({ currentPath }: AdminSidebarProps) {

--- a/packages/app/src/components/FeedbackButton.tsx
+++ b/packages/app/src/components/FeedbackButton.tsx
@@ -1,0 +1,269 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import { useTRPC } from '../api/trpc';
+
+export function FeedbackButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [rating, setRating] = useState(0);
+  const [hoverRating, setHoverRating] = useState(0);
+  const [comment, setComment] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trpc = useTRPC();
+  const submit = useMutation(trpc.feedback.submit.mutationOptions());
+
+  const closeAndReset = useCallback(() => {
+    setIsOpen(false);
+    setTimeout(() => {
+      setRating(0);
+      setHoverRating(0);
+      setComment('');
+      setSubmitted(false);
+      setError(null);
+    }, 200);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeAndReset();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, closeAndReset]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (rating < 1) {
+      setError('Please pick a rating.');
+      return;
+    }
+    setError(null);
+    try {
+      await submit.mutateAsync({
+        rating,
+        comment: comment.trim() || undefined,
+      });
+      setSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send feedback');
+    }
+  };
+
+  const displayed = hoverRating || rating;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label="Send feedback"
+        className="fixed bottom-5 right-5 z-30 flex items-center gap-2
+                   rounded-full px-4 py-2.5 text-sm font-medium shadow-lg
+                   bg-[rgba(134,199,194,0.95)] dark:bg-[rgba(134,199,194,0.85)]
+                   text-[rgba(35,75,70,1)] dark:text-[rgba(20,40,38,1)]
+                   hover:bg-[rgba(120,190,184,1)] dark:hover:bg-[rgba(150,210,205,0.95)]
+                   transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        Feedback
+      </button>
+
+      {isOpen && (
+        <>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop */}
+          <div
+            className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+            onClick={closeAndReset}
+            onKeyDown={(e) => e.key === 'Escape' && closeAndReset()}
+            role="presentation"
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="feedback-title"
+            className="fixed left-1/2 top-1/2 z-50 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2
+                       rounded-2xl p-6 shadow-2xl
+                       bg-white dark:bg-[rgba(40,40,40,0.98)]
+                       border border-[rgba(130,167,161,0.2)] dark:border-[rgba(212,232,229,0.12)]"
+          >
+            {submitted ? (
+              <div className="text-center py-4">
+                <div
+                  className="mx-auto w-12 h-12 rounded-full flex items-center justify-center mb-3
+                             bg-[rgba(134,199,194,0.3)] dark:bg-[rgba(134,199,194,0.2)]"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="w-6 h-6 text-[rgba(50,130,120,1)] dark:text-[rgba(134,199,194,0.95)]"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                </div>
+                <h3
+                  id="feedback-title"
+                  className="text-lg font-semibold text-gray-900 dark:text-[#EBEBEB]"
+                >
+                  Thanks for your feedback!
+                </h3>
+                <p className="mt-1 text-sm text-gray-500 dark:text-[#A0A0A0]">
+                  We appreciate you taking the time.
+                </p>
+                <button
+                  type="button"
+                  onClick={closeAndReset}
+                  className="mt-5 w-full rounded-lg border border-[rgba(130,167,161,0.2)] dark:border-[rgba(212,232,229,0.12)]
+                             px-4 py-2 text-sm text-gray-700 dark:text-[#EBEBEB]
+                             hover:bg-[rgba(130,167,161,0.08)] dark:hover:bg-[rgba(212,232,229,0.05)]
+                             transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit}>
+                <div className="flex items-start justify-between mb-1">
+                  <h3
+                    id="feedback-title"
+                    className="text-lg font-semibold text-gray-900 dark:text-[#EBEBEB]"
+                  >
+                    Share feedback
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={closeAndReset}
+                    aria-label="Close"
+                    className="-mt-1 -mr-1 p-1 rounded text-gray-400 hover:text-gray-600 dark:text-[#6B6B6B] dark:hover:text-[#A0A0A0]"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="w-5 h-5"
+                      aria-hidden="true"
+                    >
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+                <p className="text-sm text-gray-500 dark:text-[#A0A0A0] mb-4">
+                  How would you rate your experience?
+                </p>
+
+                {/* biome-ignore lint/a11y/noStaticElementInteractions: onMouseLeave is a hover-only enhancement */}
+                <div
+                  className="flex justify-center gap-1 mb-4"
+                  onMouseLeave={() => setHoverRating(0)}
+                >
+                  {[1, 2, 3, 4, 5].map((value) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => setRating(value)}
+                      onMouseEnter={() => setHoverRating(value)}
+                      aria-label={`${value} star${value === 1 ? '' : 's'}`}
+                      className="p-1 rounded transition-transform hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(134,199,194,0.6)]"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill={value <= displayed ? 'currentColor' : 'none'}
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        className={`w-8 h-8 transition-colors ${
+                          value <= displayed
+                            ? 'text-[rgba(245,180,55,1)]'
+                            : 'text-gray-300 dark:text-[#4A4A4A]'
+                        }`}
+                        aria-hidden="true"
+                      >
+                        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                      </svg>
+                    </button>
+                  ))}
+                </div>
+
+                <label
+                  htmlFor="feedback-comment"
+                  className="block text-sm font-medium text-gray-700 dark:text-[#B0B0B0] mb-1.5"
+                >
+                  Tell us more <span className="text-gray-400 dark:text-[#6B6B6B]">(optional)</span>
+                </label>
+                <textarea
+                  id="feedback-comment"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  rows={4}
+                  maxLength={2000}
+                  placeholder="What worked well? What could be better?"
+                  className="w-full px-3 py-2 rounded-lg text-sm
+                             bg-white dark:bg-[rgba(38,38,38,0.95)]
+                             border border-gray-200 dark:border-[rgba(255,255,255,0.09)]
+                             text-gray-900 dark:text-[#EBEBEB]
+                             placeholder-gray-400 dark:placeholder-[#4A4A4A]
+                             focus:outline-none
+                             focus:border-[rgba(130,167,161,0.6)] dark:focus:border-[rgba(212,232,229,0.3)]
+                             focus:ring-2 focus:ring-[rgba(130,167,161,0.12)] dark:focus:ring-[rgba(212,232,229,0.07)]
+                             transition-colors resize-none"
+                />
+
+                {error && (
+                  <p className="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">
+                    {error}
+                  </p>
+                )}
+
+                <div className="mt-5 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={closeAndReset}
+                    className="flex-1 rounded-lg border border-[rgba(130,167,161,0.2)] dark:border-[rgba(212,232,229,0.12)]
+                               px-4 py-2 text-sm text-gray-700 dark:text-[#A0A0A0]
+                               hover:bg-[rgba(130,167,161,0.08)] dark:hover:bg-[rgba(212,232,229,0.05)]
+                               transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submit.isPending || rating < 1}
+                    className="flex-1 rounded-lg px-4 py-2 text-sm font-medium
+                               bg-[rgba(134,199,194,0.95)] dark:bg-[rgba(134,199,194,0.85)]
+                               text-[rgba(35,75,70,1)] dark:text-[rgba(20,40,38,1)]
+                               hover:bg-[rgba(120,190,184,1)] dark:hover:bg-[rgba(150,210,205,0.95)]
+                               disabled:opacity-50 disabled:cursor-not-allowed
+                               transition-colors"
+                  >
+                    {submit.isPending ? 'Sending...' : 'Send feedback'}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/app/src/pages/admin/Feedback.tsx
+++ b/packages/app/src/pages/admin/Feedback.tsx
@@ -1,0 +1,173 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useTRPC } from '../../api/trpc';
+
+function StarRow({ rating, size = 'sm' }: { rating: number; size?: 'sm' | 'lg' }) {
+  const dim = size === 'lg' ? 'w-5 h-5' : 'w-4 h-4';
+  return (
+    <div className="flex items-center gap-0.5" role="img" aria-label={`${rating} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((v) => (
+        <svg
+          key={v}
+          viewBox="0 0 24 24"
+          fill={v <= rating ? 'currentColor' : 'none'}
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={`${dim} ${v <= rating ? 'text-[rgba(245,180,55,1)]' : 'text-gray-300'}`}
+          aria-hidden="true"
+        >
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+function MetricCard({ label, value, subtext }: { label: string; value: string; subtext?: string }) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-gray-900">{value}</p>
+      {subtext && <p className="text-xs text-gray-500 mt-1">{subtext}</p>}
+    </div>
+  );
+}
+
+export function Feedback() {
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const trpc = useTRPC();
+
+  const { data: stats } = useQuery(trpc.feedback.stats.queryOptions());
+  const { data, isLoading, isFetching } = useQuery(
+    trpc.feedback.list.queryOptions({ cursor, limit: 50 })
+  );
+
+  const maxBar = stats ? Math.max(1, ...Object.values(stats.distribution)) : 1;
+
+  return (
+    <div className="mx-auto max-w-7xl py-6 px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Feedback</h2>
+        <p className="text-sm text-gray-500">User-submitted ratings and comments</p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <MetricCard label="Total Responses" value={stats ? stats.total.toString() : '...'} />
+        <MetricCard
+          label="Average Rating"
+          value={stats ? stats.average.toFixed(2) : '...'}
+          subtext="out of 5"
+        />
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Distribution</p>
+          {stats ? (
+            <div className="space-y-1">
+              {[5, 4, 3, 2, 1].map((star) => {
+                const count = stats.distribution[star as 1 | 2 | 3 | 4 | 5];
+                const pct = (count / maxBar) * 100;
+                return (
+                  <div key={star} className="flex items-center gap-2 text-xs">
+                    <span className="w-3 text-gray-500">{star}</span>
+                    <div className="flex-1 h-2 rounded-full bg-gray-100 overflow-hidden">
+                      <div
+                        className="h-full bg-[rgba(245,180,55,0.85)]"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <span className="w-8 text-right text-gray-500">{count}</span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-400">...</p>
+          )}
+        </div>
+      </div>
+
+      {/* Feedback list */}
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-3">Recent Feedback</h3>
+        {isLoading ? (
+          <p className="text-sm text-gray-500">Loading feedback...</p>
+        ) : !data?.items.length ? (
+          <p className="text-sm text-gray-500">No feedback submitted yet.</p>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                    Time
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                    Rating
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                    User
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                    Comment
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {data.items.map((item) => (
+                  <tr key={item.id} className="hover:bg-gray-50 align-top">
+                    <td className="px-4 py-3 text-xs text-gray-500 whitespace-nowrap">
+                      {new Date(item.createdAt).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <StarRow rating={item.rating} />
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500 whitespace-nowrap">
+                      {item.user ? (
+                        <span className="flex items-center gap-2">
+                          {item.user.avatarUrl && (
+                            <img
+                              src={item.user.avatarUrl}
+                              alt=""
+                              className="w-5 h-5 rounded-full"
+                              referrerPolicy="no-referrer"
+                            />
+                          )}
+                          <span>
+                            {item.user.name || item.user.id.slice(0, 8)}
+                            <span className="ml-1 text-gray-400">({item.user.role})</span>
+                          </span>
+                        </span>
+                      ) : (
+                        <span className="text-gray-400">Anonymous</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-700 max-w-xl">
+                      {item.comment ? (
+                        <p className="whitespace-pre-wrap">{item.comment}</p>
+                      ) : (
+                        <span className="text-gray-400 italic">No comment</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {data.nextCursor && (
+              <div className="border-t border-gray-200 bg-gray-50 px-6 py-3 text-center">
+                <button
+                  type="button"
+                  onClick={() => setCursor(data.nextCursor)}
+                  disabled={isFetching}
+                  className="text-sm font-medium text-amber-600 hover:text-amber-800 disabled:opacity-50"
+                >
+                  {isFetching ? 'Loading...' : 'Load more...'}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/database/prisma/migrations/20260611000000_add_feedback/migration.sql
+++ b/packages/database/prisma/migrations/20260611000000_add_feedback/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Feedback" (
+    "id" TEXT NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Feedback_createdAt_idx" ON "Feedback"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Feedback_userId_idx" ON "Feedback"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Feedback" ADD CONSTRAINT "Feedback_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   invitationsLinked  Invitation[]          @relation("LinkedInvitations")
   observationNotes   ObservationNote[]
   telemetryEvents    TelemetryEvent[]
+  feedback           Feedback[]
 }
 
 model ContactMethod {
@@ -262,6 +263,24 @@ model ObservationNote {
 
   @@index([invitationId])
   @@index([researcherId])
+}
+
+// ============================================
+// FEEDBACK
+// ============================================
+
+model Feedback {
+  id      String @id @default(cuid())
+  rating  Int    // 1-5
+  comment String? @db.Text
+
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([userId])
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- New floating **Feedback** button (bottom-right, on Home/Invite pages) opens a modal with a 5-star rating and an optional comment.
- Works for both authenticated and anonymous users — `userId` is captured when a session exists.
- Adds `/admin/feedback` with totals, average, star distribution, and a paginated list of submissions.

## Schema / API
- New `Feedback` model: `rating Int`, `comment String? @db.Text`, `userId String?` (FK with `onDelete: SetNull`), `createdAt`.
- Migration: `20260611000000_add_feedback`.
- `feedback` tRPC router:
  - `submit` (public) — `rating` 1-5 + optional comment.
  - `list` (admin) — paginated, includes user info.
  - `stats` (admin) — total count, average, distribution by star.

## Test plan
- [x] Backend smoke: submitted via curl with rating 5+comment, rating 3 no-comment, and rating 7 (rejected by zod). Rows persisted with null `userId`.
- [x] Migration applied cleanly via docker-compose entrypoint; `Feedback` table created with indexes + FK.
- [ ] Visit `/` — confirm floating Feedback button appears bottom-right.
- [ ] Open the modal — stars highlight on hover, submit disabled until rating >= 1, Esc + backdrop close work.
- [ ] Submit without comment -> success screen, modal resets on close.
- [ ] Sign in as an `ADMIN_EMAILS` user -> visit `/admin/feedback` -> confirm sidebar item, totals, distribution bars, and entries table render.
- [ ] Verify anonymous submission shows Anonymous in the admin list.

Generated with [Claude Code](https://claude.com/claude-code)