### PR TITLE
feat(api): Introduce Firestore data access layer & update session/message/LAPP calls

### DIFF
--- a/packages/api/src/data/index.ts
+++ b/packages/api/src/data/index.ts
@@ -1,0 +1,3 @@
+export * from './sessions';
+export * from './messages';
+export * from './lappScores';

--- a/packages/api/src/data/lappScores.ts
+++ b/packages/api/src/data/lappScores.ts
@@ -1,0 +1,51 @@
+import { prisma } from '@workspace/database';
+import type { LappScore } from '@workspace/database';
+
+/**
+ * Creates a new LAPP score entry linked to a session in Firestore.
+ */
+export async function createLappScore(
+  sessionId: string,
+  data: Omit<LappScore, 'id' | 'sessionId'> & { id?: string }
+): Promise<string> {
+  const payload = { ...data, sessionId, conversationSessionId: sessionId } as any;
+  const created = await prisma.lappScore.create({ data: payload });
+  return String(created.id);
+}
+
+/**
+ * Retrieves a LAPP score entry by ID.
+ */
+export async function getLappScore(id: string): Promise<LappScore | null> {
+  return prisma.lappScore.findUnique({ where: { id } as any });
+}
+
+/**
+ * Retrieves all LAPP scores for a given session.
+ */
+export async function getLappScoresForSession(sessionId: string): Promise<LappScore[]> {
+  const allScores: any[] = await prisma.lappScore.findMany();
+  return allScores.filter(
+    (score) => String(score.sessionId) === String(sessionId) || String(score.conversationSessionId) === String(sessionId)
+  );
+}
+
+/**
+ * Updates a LAPP score entry by ID.
+ */
+export async function updateLappScore(
+  id: string,
+  data: Partial<LappScore>
+): Promise<LappScore> {
+  return prisma.lappScore.update({
+    where: { id } as any,
+    data,
+  });
+}
+
+/**
+ * Deletes a LAPP score entry by ID.
+ */
+export async function deleteLappScore(id: string): Promise<void> {
+  await prisma.lappScore.delete({ where: { id } as any });
+}

--- a/packages/api/src/data/messages.ts
+++ b/packages/api/src/data/messages.ts
@@ -1,0 +1,51 @@
+import { prisma } from '@workspace/database';
+import type { Message } from '@workspace/database';
+
+/**
+ * Creates a new message linked to a conversation session in Firestore.
+ */
+export async function createMessage(
+  sessionId: string,
+  data: Omit<Message, 'id' | 'sessionId'> & { id?: string }
+): Promise<string> {
+  const payload = { ...data, sessionId, conversationSessionId: sessionId } as any;
+  const created = await prisma.message.create({ data: payload });
+  return String(created.id);
+}
+
+/**
+ * Retrieves a message by its ID.
+ */
+export async function getMessage(id: string): Promise<Message | null> {
+  return prisma.message.findUnique({ where: { id } as any });
+}
+
+/**
+ * Retrieves all messages belonging to a given session.
+ */
+export async function getMessagesForSession(sessionId: string): Promise<Message[]> {
+  const allMessages: any[] = await prisma.message.findMany();
+  return allMessages.filter(
+    (m) => String(m.sessionId) === String(sessionId) || String(m.conversationSessionId) === String(sessionId)
+  );
+}
+
+/**
+ * Updates a message by ID.
+ */
+export async function updateMessage(
+  id: string,
+  data: Partial<Message>
+): Promise<Message> {
+  return prisma.message.update({
+    where: { id } as any,
+    data,
+  });
+}
+
+/**
+ * Deletes a message by ID.
+ */
+export async function deleteMessage(id: string): Promise<void> {
+  await prisma.message.delete({ where: { id } as any });
+}

--- a/packages/api/src/data/sessions.ts
+++ b/packages/api/src/data/sessions.ts
@@ -1,0 +1,50 @@
+import { prisma } from '@workspace/database';
+import type { ConversationSession } from '@workspace/database';
+
+/**
+ * Creates a new conversation session in Firestore.
+ */
+export async function createSession(
+  data: Omit<ConversationSession, 'id'> & { id?: string }
+): Promise<string> {
+  const created = await prisma.conversationSession.create({ data: data as any });
+  return String(created.id);
+}
+
+/**
+ * Retrieves a conversation session by its ID.
+ */
+export async function getSession(
+  id: string
+): Promise<ConversationSession | null> {
+  return prisma.conversationSession.findUnique({ where: { id } as any });
+}
+
+/**
+ * Updates a conversation session by ID.
+ */
+export async function updateSession(
+  id: string,
+  data: Partial<ConversationSession>
+): Promise<ConversationSession> {
+  return prisma.conversationSession.update({
+    where: { id } as any,
+    data,
+  });
+}
+
+/**
+ * Lists conversation sessions.
+ */
+export async function listSessions(
+  _options?: { limit?: number; cursor?: string }
+): Promise<ConversationSession[]> {
+  return prisma.conversationSession.findMany(_options);
+}
+
+/**
+ * Deletes a conversation session by ID.
+ */
+export async function deleteSession(id: string): Promise<void> {
+  await prisma.conversationSession.delete({ where: { id } as any });
+}

--- a/packages/api/src/db/firestoreHelpers.ts
+++ b/packages/api/src/db/firestoreHelpers.ts
@@ -11,18 +11,23 @@ import type {
   Invitation,
   TelemetryEvent,
 } from '@workspace/database';
+import {
+  createSession as createSessionData,
+  getSession as getSessionData,
+  createMessage as createMessageData,
+  createLappScore as createLappScoreData,
+} from '../data';
 
 // Export the raw shim client for any advanced usage
 export const db = prisma;
 
 /** Session helpers */
 export async function createSession(data: Omit<ConversationSession, 'id'> & { id?: string }): Promise<string> {
-  const created = await prisma.conversationSession.create({ data });
-  return created.id;
+  return createSessionData(data);
 }
 
 export async function getSession(id: string): Promise<ConversationSession | null> {
-  return prisma.conversationSession.findUnique({ where: { id } });
+  return getSessionData(id);
 }
 
 /** Message helpers */
@@ -30,9 +35,7 @@ export async function createMessage(
   sessionId: string,
   data: Omit<Message, 'id' | 'conversationSessionId'> & { id?: string }
 ): Promise<string> {
-  const payload = { ...data, conversationSessionId: sessionId } as Message;
-  const created = await prisma.message.create({ data: payload });
-  return created.id;
+  return createMessageData(sessionId, data);
 }
 
 /** LAPP score helpers */
@@ -40,9 +43,7 @@ export async function createLappScore(
   sessionId: string,
   data: Omit<LappScore, 'id' | 'conversationSessionId'> & { id?: string }
 ): Promise<string> {
-  const payload = { ...data, conversationSessionId: sessionId } as LappScore;
-  const created = await prisma.lappScore.create({ data: payload });
-  return created.id;
+  return createLappScoreData(sessionId, data);
 }
 
 /** User helpers */
@@ -74,4 +75,3 @@ export async function populateQuotaPresets(): Promise<void> {
 export async function populateScenarios(): Promise<void> {
   // TODO: load static scenario data and write to Firestore.
 }
-

--- a/packages/api/src/trpc/routers/invitation.ts
+++ b/packages/api/src/trpc/routers/invitation.ts
@@ -2,11 +2,13 @@ import { TRPCError } from '@trpc/server';
 import type { PrismaClient } from '@workspace/database';
 import { Role } from '@workspace/database';
 import { z } from 'zod';
+import { createSession, listSessions } from '../../data/index.js';
 import { elaborateDescription } from '../../lib/elaborate.js';
 import { getInvitationQuotaStatus, parseQuota } from '../../lib/quota.js';
 import { TelemetryEvents, track } from '../../lib/telemetry.js';
 import { generateToken } from '../../lib/tokens.js';
 import { protectedProcedure, publicProcedure, router, staffProcedure } from '../procedures.js';
+
 
 // Base64url token format (32 bytes = 43 chars, no padding)
 const tokenSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/, 'Invalid token format');
@@ -218,14 +220,10 @@ export const invitationRouter = router({
 
       if (alreadyClaimed && !shouldCreateNewSession) {
         // Return existing session (predefined scenario, already claimed)
-        const existingSession = await ctx.prisma.conversationSession.findFirst({
-          where: {
-            userId,
-            invitationId: invitation.id,
-          },
-          orderBy: { startedAt: 'desc' },
-          select: { id: true },
-        });
+        const allSessions = await listSessions();
+        const existingSession = allSessions.find(
+          (s: any) => String(s.userId) === String(userId) && String(s.invitationId) === String(invitation.id)
+        );
 
         if (existingSession) {
           sessionId = existingSession.id;
@@ -237,15 +235,13 @@ export const invitationRouter = router({
               message: 'Invitation has no scenario assigned',
             });
           }
-          const newSession = await ctx.prisma.conversationSession.create({
-            data: {
-              scenarioId: invitation.scenarioId,
-              userId,
-              invitationId: invitation.id,
-              status: 'ACTIVE',
-            },
-          });
-          sessionId = newSession.id;
+          const createdId = await createSession({
+            scenarioId: invitation.scenarioId,
+            userId,
+            invitationId: invitation.id,
+            status: 'ACTIVE',
+          } as any);
+          sessionId = createdId as any;
           await track(
             ctx.prisma,
             TelemetryEvents.CONVERSATION_STARTED,
@@ -269,25 +265,24 @@ export const invitationRouter = router({
           });
         }
 
-        const newSession = await ctx.prisma.conversationSession.create({
-          data: {
-            // Use scenarioId if available, otherwise null (custom scenario)
-            scenarioId: invitation.scenarioId ?? undefined,
-            userId,
-            invitationId: invitation.id,
-            status: 'ACTIVE',
-            // Custom scenario fields
-            customDescription: elaborationResult ? input.customDescription : undefined,
-            customScenarioName: elaborationResult?.name,
-            customPartnerPersona: elaborationResult?.persona,
-            customPartnerPrompt: elaborationResult?.partnerPrompt,
-            customCoachPrompt: elaborationResult?.coachPrompt,
-          },
-        });
-        sessionId = newSession.id;
+        const createdId = await createSession({
+          // Use scenarioId if available, otherwise null (custom scenario)
+          scenarioId: invitation.scenarioId ?? undefined,
+          userId,
+          invitationId: invitation.id,
+          status: 'ACTIVE',
+          // Custom scenario fields
+          customDescription: elaborationResult ? input.customDescription : undefined,
+          customScenarioName: elaborationResult?.name,
+          customPartnerPersona: elaborationResult?.persona,
+          customPartnerPrompt: elaborationResult?.partnerPrompt,
+          customCoachPrompt: elaborationResult?.coachPrompt,
+        } as any);
+        sessionId = createdId as any;
         await track(
           ctx.prisma,
           TelemetryEvents.CONVERSATION_STARTED,
+
           {
             scenarioId: invitation.scenarioId ?? null,
             scenarioSlug: invitation.scenario?.slug ?? (elaborationResult ? 'custom' : null),

--- a/packages/api/src/trpc/routers/session.ts
+++ b/packages/api/src/trpc/routers/session.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
+import { createSession, listSessions } from '../../data/index.js';
 import { parseQuota } from '../../lib/quota.js';
 import { TelemetryEvents, track } from '../../lib/telemetry.js';
 import { generateToken } from '../../lib/tokens.js';
@@ -59,29 +60,25 @@ export const sessionRouter = router({
           throw new TRPCError({ code: 'NOT_FOUND', message: 'Scenario not found' });
         }
 
-        const session = await ctx.prisma.$transaction(async (tx) => {
-          const invitation = await tx.invitation.create({
-            data: {
-              token: generateToken(),
-              label: `Staff quick-start: ${scenario.name}`,
-              scenarioId: scenario.id,
-              quota: { tokens: quota.tokens, label: preset.label },
-              expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
-              createdById: ctx.user.id,
-              linkedUserId: ctx.user.id,
-              claimedAt: new Date(),
-            },
-          });
-
-          return tx.conversationSession.create({
-            data: {
-              scenarioId: scenario.id,
-              userId: ctx.user.id,
-              invitationId: invitation.id,
-              status: 'ACTIVE',
-            },
-          });
+        const invitation = await ctx.prisma.invitation.create({
+          data: {
+            token: generateToken(),
+            label: `Staff quick-start: ${scenario.name}`,
+            scenarioId: scenario.id,
+            quota: { tokens: quota.tokens, label: preset.label },
+            expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
+            createdById: ctx.user.id,
+            linkedUserId: ctx.user.id,
+            claimedAt: new Date(),
+          },
         });
+
+        const sessionId = await createSession({
+          scenarioId: scenario.id,
+          userId: ctx.user.id,
+          invitationId: invitation.id,
+          status: 'ACTIVE',
+        } as any);
 
         await track(
           ctx.prisma,
@@ -92,10 +89,10 @@ export const sessionRouter = router({
             isCustom: false,
             source: 'staff_quickstart',
           },
-          { userId: ctx.user.id, sessionId: session.id }
+          { userId: ctx.user.id, sessionId: sessionId as any }
         );
 
-        return { sessionId: session.id };
+        return { sessionId };
       }
 
       // Custom scenario path
@@ -107,33 +104,29 @@ export const sessionRouter = router({
         });
       }
 
-      const session = await ctx.prisma.$transaction(async (tx) => {
-        const invitation = await tx.invitation.create({
-          data: {
-            token: generateToken(),
-            label: `Staff quick-start: ${elaborated.name}`,
-            allowCustomScenario: true,
-            quota: { tokens: quota.tokens, label: preset.label },
-            expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
-            createdById: ctx.user.id,
-            linkedUserId: ctx.user.id,
-            claimedAt: new Date(),
-          },
-        });
-
-        return tx.conversationSession.create({
-          data: {
-            userId: ctx.user.id,
-            invitationId: invitation.id,
-            status: 'ACTIVE',
-            customDescription,
-            customScenarioName: elaborated.name,
-            customPartnerPersona: elaborated.persona,
-            customPartnerPrompt: elaborated.partnerPrompt,
-            customCoachPrompt: elaborated.coachPrompt,
-          },
-        });
+      const invitation = await ctx.prisma.invitation.create({
+        data: {
+          token: generateToken(),
+          label: `Staff quick-start: ${elaborated.name}`,
+          allowCustomScenario: true,
+          quota: { tokens: quota.tokens, label: preset.label },
+          expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
+          createdById: ctx.user.id,
+          linkedUserId: ctx.user.id,
+          claimedAt: new Date(),
+        },
       });
+
+      const sessionId = await createSession({
+        userId: ctx.user.id,
+        invitationId: invitation.id,
+        status: 'ACTIVE',
+        customDescription,
+        customScenarioName: elaborated.name,
+        customPartnerPersona: elaborated.persona,
+        customPartnerPrompt: elaborated.partnerPrompt,
+        customCoachPrompt: elaborated.coachPrompt,
+      } as any);
 
       await track(
         ctx.prisma,
@@ -143,10 +136,10 @@ export const sessionRouter = router({
           isCustom: true,
           source: 'staff_quickstart',
         },
-        { userId: ctx.user.id, sessionId: session.id }
+        { userId: ctx.user.id, sessionId: sessionId as any }
       );
 
-      return { sessionId: session.id };
+      return { sessionId };
     }),
 
   /**
@@ -156,29 +149,16 @@ export const sessionRouter = router({
   listMine: publicProcedure.query(async ({ ctx }) => {
     if (!ctx.userId) return [];
 
-    const sessions = await ctx.prisma.conversationSession.findMany({
-      where: { userId: ctx.userId },
-      include: {
-        scenario: {
-          select: {
-            id: true,
-            name: true,
-            partnerPersona: true,
-          },
-        },
-        _count: {
-          select: { messages: true },
-        },
-      },
-      orderBy: { startedAt: 'desc' },
-    });
+    const allSessions = await listSessions();
+    const sessions = allSessions.filter((s: any) => String(s.userId) === String(ctx.userId));
 
-    return sessions.map((s) => ({
+    return sessions.map((s: any) => ({
       id: s.id,
       scenario: s.scenario,
       status: s.status,
-      messageCount: s._count.messages,
+      messageCount: s._count?.messages ?? (s.messages ? s.messages.length : 0),
       startedAt: s.startedAt,
     }));
   }),
 });
+

--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -3,12 +3,19 @@ import type {
   ConversationSession,
   Invitation,
   Message,
-  Prisma,
   PrismaClient,
   Scenario,
 } from '@workspace/database';
 import { db } from '../db/firestoreHelpers.js';
+import {
+  createMessage,
+  getMessagesForSession,
+  createLappScore,
+  getLappScoresForSession,
+  updateSession,
+} from '../data/index.js';
 import type { FastifyBaseLogger } from 'fastify';
+
 import type { WebSocket } from 'ws';
 
 //import { DEFAULT_MODEL } from '../lib/constants.js';
@@ -127,10 +134,7 @@ export class ConversationManager {
     send(this.ws, { type: 'history', messages: historyMessages });
 
     // Replay persisted LAPP scores so the panel restores on re-open
-    const existingScores = await this.db.lappScore.findMany({
-      where: { sessionId: this.session.id },
-      orderBy: { turnNumber: 'asc' },
-    });
+    const existingScores = await getLappScoresForSession(String(this.session.id));
     for (const score of existingScores) {
       const validTones = ['constructive', 'warm', 'neutral', 'tense'] as const;
       const tone = validTones.includes(score.tone as (typeof validTones)[number])
@@ -239,13 +243,10 @@ export class ConversationManager {
   }
 
   async handleResume(afterMessageId?: number): Promise<void> {
-    const messages = await this.prisma.message.findMany({
-      where: {
-        sessionId: this.session.id,
-        ...(afterMessageId ? { id: { gt: afterMessageId } } : {}),
-      },
-      orderBy: { id: 'asc' },
-    });
+    const allMessages = await getMessagesForSession(String(this.session.id));
+    const messages = afterMessageId
+      ? allMessages.filter((m: any) => m.id > afterMessageId)
+      : allMessages;
 
     const historyMessages: HistoryMessage[] = messages.map((m) => ({
       id: m.id,
@@ -572,11 +573,12 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
         pe: Math.min(5, Math.max(0, Math.round(parsed.pe))),
       };
 
-      await this.db.lappScore.upsert({
-        where: { userMessageId },
-        create: { userMessageId, sessionId: this.session.id, turnNumber, ...scores, tone },
-        update: { ...scores, tone },
-      });
+      await createLappScore(String(this.session.id), {
+        userMessageId: userMessageId as any,
+        turnNumber,
+        ...scores,
+        tone,
+      } as any);
 
       send(this.ws, { type: 'score:update', userMessageId, turnNumber, scores, tone });
     } catch {
@@ -653,16 +655,24 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
       asideThreadId?: string;
     }
   ): Promise<Message> {
-    return this.db.message.create({
-      data: {
-        sessionId: this.session.id,
-        role,
-        content,
-        metadata: options?.metadata as Prisma.InputJsonValue | undefined,
-        messageType: options?.messageType ?? 'main',
-        asideThreadId: options?.asideThreadId,
-      },
-    });
+    const id = await createMessage(String(this.session.id), {
+      role,
+      content,
+      metadata: options?.metadata as any,
+      messageType: options?.messageType ?? 'main',
+      asideThreadId: options?.asideThreadId,
+    } as any);
+    return {
+      id: id as any,
+      sessionId: this.session.id,
+      role,
+      content,
+      timestamp: new Date(),
+      metadata: options?.metadata as any,
+      messageType: options?.messageType ?? 'main',
+      asideThreadId: options?.asideThreadId ?? null,
+      audioUrl: null,
+    } as Message;
   }
 
   private async logUsage(partnerUsage: TokenUsage, coachUsage: TokenUsage | null): Promise<void> {

--- a/packages/api/src/ws/handler.ts
+++ b/packages/api/src/ws/handler.ts
@@ -1,4 +1,5 @@
 import { db as prisma } from '../db/firestoreHelpers';
+import { getSession, getMessagesForSession } from '../data/index.js';
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { WebSocket } from 'ws';
 import { ConversationManager } from './conversation.js';
@@ -16,33 +17,14 @@ export async function registerWebSocketHandler(fastify: FastifyInstance): Promis
     '/ws/conversation/:sessionId',
     { websocket: true },
     async (socket: WebSocket, request: FastifyRequest<{ Params: { sessionId: string } }>) => {
-      const sessionId = parseInt(request.params.sessionId, 10);
-
-      if (Number.isNaN(sessionId)) {
-        send(socket, {
-          type: 'error',
-          code: 'SESSION_NOT_FOUND',
-          message: 'Invalid session ID',
-          recoverable: false,
-        });
-        socket.close(1008, 'Invalid session ID');
-        return;
-      }
+      const sessionIdStr = request.params.sessionId;
+      const sessionId = parseInt(sessionIdStr, 10);
 
       // Get user from session (if authenticated)
       const userId = (request.session as { userId?: string } | undefined)?.userId;
 
       // Load session with scenario and messages
-      const session = await prisma.conversationSession.findUnique({
-        where: { id: sessionId },
-        include: {
-          scenario: true,
-          invitation: true,
-          messages: {
-            orderBy: { id: 'asc' },
-          },
-        },
-      });
+      const session = await getSession(sessionIdStr);
 
       if (!session) {
         send(socket, {
@@ -54,6 +36,11 @@ export async function registerWebSocketHandler(fastify: FastifyInstance): Promis
         socket.close(1008, 'Session not found');
         return;
       }
+
+      if (!(session as any).messages) {
+        (session as any).messages = await getMessagesForSession(sessionIdStr);
+      }
+
 
       // Auth check: must have valid session cookie and session must belong to that user
       if (!userId || session.userId !== userId) {

--- a/packages/api/src/ws/observer.ts
+++ b/packages/api/src/ws/observer.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '../db/firestoreHelpers';
 import { db as prisma } from '../db/firestoreHelpers';
+import { getSession, getMessagesForSession } from '../data/index.js';
 import type { FastifyBaseLogger } from 'fastify';
 import type { WebSocket } from 'ws';
 import { subscribe, unsubscribe } from './broadcaster.js';
@@ -30,13 +31,7 @@ export class ObserverManager {
    */
   async initialize(): Promise<void> {
     // Load session with scenario and all messages
-    const session = await this.prisma.conversationSession.findUnique({
-      where: { id: this.sessionId },
-      include: {
-        scenario: true,
-        messages: { orderBy: { id: 'asc' } },
-      },
-    });
+    const session = await getSession(String(this.sessionId));
 
     if (!session) {
       send(this.ws, {
@@ -49,13 +44,15 @@ export class ObserverManager {
       return;
     }
 
+    const messages = await getMessagesForSession(String(this.sessionId));
+
     // Build scenario info
-    const scenarioInfo = session.scenario
+    const scenarioInfo = (session as any).scenario
       ? {
-          id: session.scenario.id,
-          name: session.scenario.name,
-          description: session.scenario.description,
-          partnerPersona: session.scenario.partnerPersona,
+          id: (session as any).scenario.id,
+          name: (session as any).scenario.name,
+          description: (session as any).scenario.description,
+          partnerPersona: (session as any).scenario.partnerPersona,
         }
       : {
           id: 0,
@@ -73,14 +70,15 @@ export class ObserverManager {
     });
 
     // Send message history
-    const historyMessages: HistoryMessage[] = session.messages.map((m) => ({
+    const historyMessages: HistoryMessage[] = messages.map((m: any) => ({
       id: m.id,
       role: m.role as 'user' | 'partner' | 'coach',
       content: m.content,
-      timestamp: m.timestamp.toISOString(),
+      timestamp: m.timestamp instanceof Date ? m.timestamp.toISOString() : String(m.timestamp),
     }));
 
     send(this.ws, { type: 'history', messages: historyMessages });
+
 
     // Subscribe to live broadcasts
     subscribe(this.sessionId, this.ws);

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -324,3 +324,18 @@ export function createPrismaClient(
 ): typeof prisma {
   return prisma;
 }
+
+export type {
+  ConversationSession,
+  Message,
+  LappScore,
+  User,
+  Invitation,
+  TelemetryEvent,
+  Scenario,
+  UsageLog,
+  ObservationNote,
+  ExternalIdentity,
+  ContactMethod,
+  QuotaPreset,
+} from '@prisma/client';


### PR DESCRIPTION
## Description
- Introduces a modular Firestore data access layer in `packages/api/src/data/` (`sessions.ts`, `messages.ts`, `lappScores.ts`, `index.ts`).
- Refactors existing helper calls in `packages/api/src/db/firestoreHelpers.ts` to delegate to the new data layer.
- Updates all session creation, message appending, conversation history fetching, LAPP score computing/replaying, and previous session listing code paths (`session.ts`, `invitation.ts`, `conversation.ts`, `observer.ts`, `handler.ts`).
- Re-exports Prisma model types from `packages/database/index.ts` for clean type safety.