### PR TITLE
Fix Firestore session atomicity

### DIFF
--- a/packages/api/src/data/atomic.test.ts
+++ b/packages/api/src/data/atomic.test.ts
@@ -1,0 +1,244 @@
+import type { Firestore } from '@google-cloud/firestore';
+import { describe, expect, it } from 'vitest';
+import { completeSession, createMessageAndIncrementSession } from './atomic.js';
+
+interface Ref {
+  id: string;
+  path: string;
+}
+
+class InMemoryFirestore {
+  private documents = new Map<string, Record<string, unknown>>();
+  private nextId = 0;
+  private transactionQueue = Promise.resolve();
+  failCommit = false;
+
+  collection(name: string) {
+    return {
+      doc: (id = `generated-${++this.nextId}`): Ref => ({
+        id,
+        path: `${name}/${id}`,
+      }),
+    };
+  }
+
+  seed(path: string, data: Record<string, unknown>) {
+    this.documents.set(path, structuredClone(data));
+  }
+
+  read(path: string) {
+    const value = this.documents.get(path);
+    return value ? structuredClone(value) : undefined;
+  }
+
+  countCollection(name: string) {
+    return [...this.documents.keys()].filter((path) => path.startsWith(`${name}/`)).length;
+  }
+
+  async runTransaction<T>(
+    callback: (transaction: {
+      get: (ref: Ref) => Promise<{
+        id: string;
+        exists: boolean;
+        data: () => Record<string, unknown> | undefined;
+      }>;
+      create: (ref: Ref, data: Record<string, unknown>) => void;
+      update: (ref: Ref, data: Record<string, unknown>) => void;
+    }) => Promise<T>
+  ): Promise<T> {
+    const previous = this.transactionQueue;
+    let release!: () => void;
+    this.transactionQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+
+    const staged = new Map<string, Record<string, unknown>>();
+    try {
+      const result = await callback({
+        get: async (ref) => {
+          const data = staged.get(ref.path) ?? this.documents.get(ref.path);
+          return {
+            id: ref.id,
+            exists: data !== undefined,
+            data: () => (data ? structuredClone(data) : undefined),
+          };
+        },
+        create: (ref, data) => {
+          if (this.documents.has(ref.path) || staged.has(ref.path)) {
+            throw new Error('already exists');
+          }
+          staged.set(ref.path, structuredClone(data));
+        },
+        update: (ref, data) => {
+          const current = staged.get(ref.path) ?? this.documents.get(ref.path);
+          if (!current) throw new Error('not found');
+          staged.set(ref.path, { ...structuredClone(current), ...structuredClone(data) });
+        },
+      });
+
+      if (this.failCommit) throw new Error('injected commit failure');
+      for (const [path, data] of staged) this.documents.set(path, data);
+      return result;
+    } finally {
+      release();
+    }
+  }
+}
+
+function asFirestore(fake: InMemoryFirestore): Firestore {
+  return fake as unknown as Firestore;
+}
+
+describe('Firestore atomic session operations', () => {
+  it('does not lose concurrent totalMessages increments', async () => {
+    const fake = new InMemoryFirestore();
+    fake.seed('conversationSessions/session-1', { totalMessages: 0 });
+
+    await Promise.all(
+      Array.from({ length: 25 }, (_, index) =>
+        createMessageAndIncrementSession(
+          'session-1',
+          {
+            id: `message-${index}`,
+            role: 'user',
+            content: `message ${index}`,
+          } as never,
+          asFirestore(fake)
+        )
+      )
+    );
+
+    expect(fake.read('conversationSessions/session-1')?.totalMessages).toBe(25);
+    expect(fake.countCollection('messages')).toBe(25);
+  });
+
+  it('stores the message and session metadata update together', async () => {
+    const fake = new InMemoryFirestore();
+    fake.seed('conversationSessions/session-1', { totalMessages: 4 });
+
+    await createMessageAndIncrementSession(
+      'session-1',
+      { id: 'message-1', role: 'partner', content: 'hello' } as never,
+      asFirestore(fake)
+    );
+
+    expect(fake.read('messages/message-1')).toMatchObject({
+      sessionId: 'session-1',
+      conversationSessionId: 'session-1',
+      role: 'partner',
+    });
+    expect(fake.read('conversationSessions/session-1')?.totalMessages).toBe(5);
+  });
+
+  it('leaves no partial message when the transaction commit fails', async () => {
+    const fake = new InMemoryFirestore();
+    fake.seed('conversationSessions/session-1', { totalMessages: 2 });
+    fake.failCommit = true;
+
+    await expect(
+      createMessageAndIncrementSession(
+        'session-1',
+        { id: 'message-1', role: 'user', content: 'hello' } as never,
+        asFirestore(fake)
+      )
+    ).rejects.toThrow('injected commit failure');
+
+    expect(fake.read('messages/message-1')).toBeUndefined();
+    expect(fake.read('conversationSessions/session-1')?.totalMessages).toBe(2);
+  });
+
+  it('does not add messages after a concurrent completion wins', async () => {
+    const fake = new InMemoryFirestore();
+    fake.seed('conversationSessions/session-1', {
+      status: 'ACTIVE',
+      startedAt: new Date('2026-07-30T12:00:00.000Z'),
+      endedAt: null,
+      durationSeconds: null,
+      totalMessages: 0,
+    });
+
+    await completeSession('session-1', new Date('2026-07-30T12:01:00.000Z'), asFirestore(fake));
+
+    await expect(
+      createMessageAndIncrementSession(
+        'session-1',
+        { id: 'late-message', role: 'user', content: 'too late' } as never,
+        asFirestore(fake)
+      )
+    ).rejects.toThrow('Cannot add a message to a completed session');
+    expect(fake.read('messages/late-message')).toBeUndefined();
+    expect(fake.read('conversationSessions/session-1')?.totalMessages).toBe(0);
+  });
+
+  it('atomically completes a session', async () => {
+    const fake = new InMemoryFirestore();
+    const startedAt = new Date('2026-07-30T12:00:00.000Z');
+    const endedAt = new Date('2026-07-30T12:01:30.000Z');
+    fake.seed('conversationSessions/session-1', {
+      status: 'ACTIVE',
+      startedAt,
+      endedAt: null,
+      durationSeconds: null,
+    });
+
+    const result = await completeSession('session-1', endedAt, asFirestore(fake));
+
+    expect(result).toEqual({ completed: true, endedAt, durationSeconds: 90 });
+    expect(fake.read('conversationSessions/session-1')).toMatchObject({
+      status: 'COMPLETED',
+      endedAt,
+      durationSeconds: 90,
+    });
+  });
+
+  it('keeps the original completion values on repeated completion', async () => {
+    const fake = new InMemoryFirestore();
+    const startedAt = new Date('2026-07-30T12:00:00.000Z');
+    const firstEnd = new Date('2026-07-30T12:01:00.000Z');
+    fake.seed('conversationSessions/session-1', {
+      status: 'ACTIVE',
+      startedAt,
+      endedAt: null,
+      durationSeconds: null,
+    });
+
+    await completeSession('session-1', firstEnd, asFirestore(fake));
+    const repeated = await completeSession(
+      'session-1',
+      new Date('2026-07-30T12:05:00.000Z'),
+      asFirestore(fake)
+    );
+
+    expect(repeated).toEqual({
+      completed: false,
+      endedAt: firstEnd,
+      durationSeconds: 60,
+    });
+    expect(fake.read('conversationSessions/session-1')).toMatchObject({
+      endedAt: firstEnd,
+      durationSeconds: 60,
+    });
+  });
+
+  it('leaves all completion fields unchanged when commit fails', async () => {
+    const fake = new InMemoryFirestore();
+    fake.seed('conversationSessions/session-1', {
+      status: 'ACTIVE',
+      startedAt: new Date('2026-07-30T12:00:00.000Z'),
+      endedAt: null,
+      durationSeconds: null,
+    });
+    fake.failCommit = true;
+
+    await expect(
+      completeSession('session-1', new Date('2026-07-30T12:01:00.000Z'), asFirestore(fake))
+    ).rejects.toThrow('injected commit failure');
+
+    expect(fake.read('conversationSessions/session-1')).toMatchObject({
+      status: 'ACTIVE',
+      endedAt: null,
+      durationSeconds: null,
+    });
+  });
+});

--- a/packages/api/src/data/atomic.ts
+++ b/packages/api/src/data/atomic.ts
@@ -1,0 +1,136 @@
+import type { DocumentData, DocumentSnapshot, Firestore, Timestamp } from '@google-cloud/firestore';
+import type { ConversationSession, Message } from '@workspace/database';
+import { getFirestoreClient } from '@workspace/database';
+
+const SESSION_COLLECTION = 'conversationSessions';
+const MESSAGE_COLLECTION = 'messages';
+
+type MessageCreateData = Omit<Message, 'id' | 'sessionId'> & {
+  id?: string;
+  sessionId?: string | number;
+};
+
+export interface CompletionResult {
+  completed: boolean;
+  endedAt: Date;
+  durationSeconds: number;
+}
+
+function asDate(value: Date | Timestamp | undefined, field: string): Date {
+  if (value instanceof Date) return value;
+  if (value && typeof value.toDate === 'function') return value.toDate();
+  throw new Error(`Session ${field} is missing or invalid`);
+}
+
+function snapshotData(snapshot: DocumentSnapshot<DocumentData>, entity: string): DocumentData {
+  if (!snapshot.exists) throw new Error(`${entity} not found`);
+  return snapshot.data() ?? {};
+}
+
+/**
+ * Stores a message and increments its session counter in one transaction.
+ * The callback contains only Firestore reads and writes because it may retry.
+ */
+export async function createMessageAndIncrementSession(
+  sessionId: string,
+  data: MessageCreateData,
+  firestore: Firestore = getFirestoreClient()
+): Promise<string> {
+  const sessionRef = firestore.collection(SESSION_COLLECTION).doc(String(sessionId));
+  const messageRef = data.id
+    ? firestore.collection(MESSAGE_COLLECTION).doc(String(data.id))
+    : firestore.collection(MESSAGE_COLLECTION).doc();
+
+  await firestore.runTransaction(async (transaction) => {
+    const sessionSnapshot = await transaction.get(sessionRef);
+    const session = snapshotData(sessionSnapshot, 'Session');
+    if (session.endedAt || session.status === 'COMPLETED') {
+      throw new Error('Cannot add a message to a completed session');
+    }
+    const totalMessages = typeof session.totalMessages === 'number' ? session.totalMessages : 0;
+    const { id: _id, ...messageData } = data;
+    const payload = {
+      ...messageData,
+      sessionId,
+      conversationSessionId: sessionId,
+      timestamp: data.timestamp ?? new Date(),
+    };
+
+    transaction.create(messageRef, payload);
+    transaction.update(sessionRef, { totalMessages: totalMessages + 1 });
+  });
+
+  return messageRef.id;
+}
+
+/**
+ * Completes a session exactly once. Repeated calls retain the original
+ * completion timestamp and duration.
+ */
+export async function completeSession(
+  sessionId: string,
+  completedAt: Date,
+  firestore: Firestore = getFirestoreClient()
+): Promise<CompletionResult> {
+  const sessionRef = firestore.collection(SESSION_COLLECTION).doc(String(sessionId));
+
+  return firestore.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(sessionRef);
+    const session = snapshotData(snapshot, 'Session');
+
+    if (session.endedAt) {
+      return {
+        completed: false,
+        endedAt: asDate(session.endedAt, 'endedAt'),
+        durationSeconds:
+          typeof session.durationSeconds === 'number'
+            ? session.durationSeconds
+            : Math.round(
+                (asDate(session.endedAt, 'endedAt').getTime() -
+                  asDate(session.startedAt, 'startedAt').getTime()) /
+                  1000
+              ),
+      };
+    }
+
+    const startedAt = asDate(session.startedAt, 'startedAt');
+    const durationSeconds = Math.max(
+      0,
+      Math.round((completedAt.getTime() - startedAt.getTime()) / 1000)
+    );
+
+    transaction.update(sessionRef, {
+      status: 'COMPLETED',
+      endedAt: completedAt,
+      durationSeconds,
+    });
+
+    return { completed: true, endedAt: completedAt, durationSeconds };
+  });
+}
+
+/**
+ * Status changes use a transaction so concurrent transitions cannot silently
+ * overwrite one another. Completion must go through completeSession.
+ */
+export async function updateSessionAtomically(
+  sessionId: string,
+  data: Partial<ConversationSession>,
+  firestore: Firestore = getFirestoreClient()
+): Promise<ConversationSession> {
+  if ('endedAt' in data || 'durationSeconds' in data) {
+    throw new Error('Session completion fields must be updated with completeSession');
+  }
+
+  const sessionRef = firestore.collection(SESSION_COLLECTION).doc(String(sessionId));
+  return firestore.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(sessionRef);
+    const current = snapshotData(snapshot, 'Session');
+    transaction.update(sessionRef, data as DocumentData);
+    return {
+      id: snapshot.id,
+      ...current,
+      ...data,
+    } as ConversationSession;
+  });
+}

--- a/packages/api/src/data/index.ts
+++ b/packages/api/src/data/index.ts
@@ -1,3 +1,4 @@
 export * from './sessions';
 export * from './messages';
 export * from './lappScores';
+export * from './atomic';

--- a/packages/api/src/data/messages.ts
+++ b/packages/api/src/data/messages.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@workspace/database';
 import type { Message } from '@workspace/database';
+import { createMessageAndIncrementSession } from './atomic.js';
 
 /**
  * Creates a new message linked to a conversation session in Firestore.
@@ -8,9 +9,7 @@ export async function createMessage(
   sessionId: string,
   data: Omit<Message, 'id' | 'sessionId'> & { id?: string }
 ): Promise<string> {
-  const payload = { ...data, sessionId, conversationSessionId: sessionId } as any;
-  const created = await prisma.message.create({ data: payload });
-  return String(created.id);
+  return createMessageAndIncrementSession(sessionId, data);
 }
 
 /**

--- a/packages/api/src/data/sessions.ts
+++ b/packages/api/src/data/sessions.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@workspace/database';
 import type { ConversationSession } from '@workspace/database';
+import { updateSessionAtomically } from './atomic.js';
 
 /**
  * Creates a new conversation session in Firestore.
@@ -27,10 +28,7 @@ export async function updateSession(
   id: string,
   data: Partial<ConversationSession>
 ): Promise<ConversationSession> {
-  return prisma.conversationSession.update({
-    where: { id } as any,
-    data,
-  });
+  return updateSessionAtomically(id, data);
 }
 
 /**

--- a/packages/api/src/ws/conversation.atomic.test.ts
+++ b/packages/api/src/ws/conversation.atomic.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { completeSession, track } = vi.hoisted(() => ({
+  completeSession: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock('../data/index.js', () => ({
+  completeSession,
+  createLappScore: vi.fn(),
+  createMessage: vi.fn(),
+  getLappScoresForSession: vi.fn().mockResolvedValue([]),
+  getMessagesForSession: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../lib/telemetry.js', () => ({
+  TelemetryEvents: {
+    CONVERSATION_ENDED: 'conversation_ended',
+    MESSAGE_SENT: 'message_sent',
+  },
+  track,
+}));
+
+import { ConversationManager } from './conversation.js';
+
+describe('ConversationManager session completion', () => {
+  beforeEach(() => {
+    completeSession.mockReset();
+    track.mockReset();
+  });
+
+  it('tracks only the WebSocket close that atomically completes the session', async () => {
+    completeSession
+      .mockResolvedValueOnce({
+        completed: true,
+        endedAt: new Date('2026-07-30T12:01:00.000Z'),
+        durationSeconds: 60,
+      })
+      .mockResolvedValueOnce({
+        completed: false,
+        endedAt: new Date('2026-07-30T12:01:00.000Z'),
+        durationSeconds: 60,
+      });
+
+    const manager = new ConversationManager(
+      { send: vi.fn() } as never,
+      {} as never,
+      {
+        id: 42,
+        startedAt: new Date('2026-07-30T12:00:00.000Z'),
+        messages: [],
+        scenario: { slug: 'practice' },
+        invitation: null,
+        invitationId: null,
+        userId: 'user-1',
+        customPartnerPersona: null,
+      } as never,
+      { error: vi.fn() } as never
+    );
+
+    await manager.onClose('disconnect');
+    await manager.onClose('idle_timeout');
+
+    expect(completeSession).toHaveBeenNthCalledWith(1, '42', expect.any(Date));
+    expect(completeSession).toHaveBeenNthCalledWith(2, '42', expect.any(Date));
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith(
+      expect.anything(),
+      'conversation_ended',
+      expect.objectContaining({
+        reason: 'disconnect',
+        durationMs: 60_000,
+        totalMessages: 0,
+      }),
+      { userId: 'user-1', sessionId: 42 }
+    );
+  });
+});

--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -12,7 +12,7 @@ import {
   getMessagesForSession,
   createLappScore,
   getLappScoresForSession,
-  updateSession,
+  completeSession,
 } from '../data/index.js';
 import type { FastifyBaseLogger } from 'fastify';
 
@@ -78,6 +78,7 @@ interface SessionWithScenario extends ConversationSession {
 
 export class ConversationManager {
   private ws: WebSocket;
+  private db: PrismaClient;
   private prisma: PrismaClient;
   private session: SessionWithScenario;
   private logger: FastifyBaseLogger;
@@ -93,6 +94,7 @@ export class ConversationManager {
   ) {
     this.ws = ws;
     this.db = db;
+    this.prisma = db;
     this.session = session;
     this.logger = logger;
   }
@@ -208,10 +210,6 @@ export class ConversationManager {
         send(this.ws, { type: 'exchange:complete' });
         await this.logUsage(partnerResult.usage, null);
         await this.checkQuotaWarning();
-        await this.db.conversationSession.update({
-          where: { id: this.session.id },
-          data: { totalMessages: { increment: 2 } },
-        });
       } else {
         const coachResult = await this.streamResponse('coach');
         if (!coachResult) {
@@ -220,10 +218,6 @@ export class ConversationManager {
         }
         await this.logUsage(partnerResult.usage, coachResult.usage);
         await this.checkQuotaWarning();
-        await this.db.conversationSession.update({
-          where: { id: this.session.id },
-          data: { totalMessages: { increment: 3 } },
-        });
 
         // Fire-and-forget LAPP scorer (does not block the next exchange)
         this.runLappScorer(userMsg.id, content, partnerResult.content, turnNumber).catch(() => {});
@@ -743,18 +737,10 @@ Return ONLY this JSON: {"l":N,"a":N,"p":N,"pe":N,"tone":"X"}`;
   }
 
   async onClose(reason: 'idle_timeout' | 'disconnect'): Promise<void> {
-    // Idempotent: only the first close transitions the session to ended.
     const now = new Date();
-    const durationMs = now.getTime() - this.session.startedAt.getTime();
-    const result = await this.db.conversationSession.updateMany({
-      where: { id: this.session.id, endedAt: null },
-      data: {
-        endedAt: now,
-        durationSeconds: Math.round(durationMs / 1000),
-        status: 'COMPLETED',
-      },
-    });
-    if (result.count === 0) return;
+    const result = await completeSession(String(this.session.id), now);
+    if (!result.completed) return;
+    const durationMs = result.durationSeconds * 1000;
 
     await track(
       this.prisma,

--- a/packages/api/vitest.atomic.config.ts
+++ b/packages/api/vitest.atomic.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/data/atomic.test.ts', 'src/ws/conversation.atomic.test.ts'],
+  },
+});

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -1,6 +1,8 @@
 import type { Firestore, DocumentData, WithFieldValue } from '@google-cloud/firestore';
 import { getFirestoreClient } from './src/firestoreClient';
 
+export { getFirestoreClient } from './src/firestoreClient';
+
 function getDb(): Firestore {
   return getFirestoreClient();
 }


### PR DESCRIPTION
## Summary
- adds Firestore transactions for dependent session updates
- prevents lost totalMessages increments
- makes session completion status, endedAt, and durationSeconds atomic and idempotent
- groups session and message writes atomically
- adds focused Firestore atomicity and WebSocket tests

## Testing
- targeted atomicity tests passed
- database type-check passed
- full API type-check has only pre-existing diagnostics from main
- this branch introduced 0 new TypeScript diagnostics

## Safety
- did not run the migration script
- did not access production Firestore or Cloud SQL
- did not stage or commit .env