### PR TITLE
Add Qualtrics study flow

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -13,9 +13,6 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
 COPY packages/database ./packages/database
 COPY packages/api ./packages/api
 
-# Copy QUICKSTART.md for the setup guide endpoint
-COPY QUICKSTART.md ./
-
 # Install dependencies (workspace packages will be properly linked)
 RUN pnpm install --frozen-lockfile
 

--- a/packages/api/src/trpc/router.ts
+++ b/packages/api/src/trpc/router.ts
@@ -5,6 +5,7 @@ import { invitationRouter } from './routers/invitation.js';
 import { observationRouter } from './routers/observation.js';
 import { scenarioRouter } from './routers/scenario.js';
 import { sessionRouter } from './routers/session.js';
+import { studyRouter } from './routers/study.js';
 import { telemetryRouter } from './routers/telemetry.js';
 import { userRouter } from './routers/user.js';
 
@@ -15,6 +16,7 @@ export const appRouter = router({
   observation: observationRouter,
   scenario: scenarioRouter,
   session: sessionRouter,
+  study: studyRouter,
   telemetry: telemetryRouter,
   user: userRouter,
 });

--- a/packages/api/src/trpc/routers/study.ts
+++ b/packages/api/src/trpc/routers/study.ts
@@ -1,0 +1,296 @@
+import { TRPCError } from "@trpc/server";
+import { Role } from "@workspace/database";
+import { z } from "zod";
+import { completeSession } from "../../data/index.js";
+import { createSession } from "../../data/sessions.js";
+import { TelemetryEvents, track } from "../../lib/telemetry.js";
+import { publicProcedure, router } from "../procedures.js";
+
+const STUDY_TOPICS = [
+	"Environment",
+	"Freedom of speech",
+	"Guns",
+	"Healthcare",
+	"Housing",
+	"Immigration",
+	"Taxes",
+	"Pick your own topic",
+] as const;
+
+const STUDY_PARAM_CONTRACT = {
+	pid: "Prolific participant id; maps to PROLIFIC_PID in Qualtrics",
+	topic: "Exact topic label from Qualtrics",
+	condition: "0 = control, 1 = coaching treatment",
+	partner: "0 = male partner, 1 = female partner",
+	party: "Participant party/ideology from Qualtrics; app maps to opposite partner ideology",
+	rid: "Qualtrics pre-survey ResponseID",
+	owntopic: "Free text when topic is Pick your own topic",
+} as const;
+
+type StudyCondition = 0 | 1;
+type PartnerGender = "male" | "female";
+type PartnerIdeology = "left" | "right";
+
+const enterInput = z.object({
+	pid: z.string().trim().min(1).max(256),
+	topic: z.enum(STUDY_TOPICS),
+	condition: z.union([z.literal("0"), z.literal("1"), z.number().int().min(0).max(1)]),
+	partner: z.union([z.literal("0"), z.literal("1"), z.number().int().min(0).max(1)]),
+	party: z.string().trim().max(256).optional(),
+	rid: z.string().trim().max(256).optional(),
+	owntopic: z.string().trim().max(500).optional(),
+});
+
+const finishInput = z.object({
+	sessionId: z.string().min(1),
+	endType: z.enum(["participant_finish", "early_exit", "soft_cap", "hard_stop"]),
+});
+
+function parseBinary(value: "0" | "1" | number): 0 | 1 {
+	return Number(value) === 1 ? 1 : 0;
+}
+
+function normalizePartySide(party: string | undefined): "left" | "right" | "independent" {
+	const value = (party ?? "").toLowerCase();
+
+	if (
+		value.includes("democrat") ||
+		value.includes("left") ||
+		value.includes("liberal") ||
+		value.includes("progressive")
+	) {
+		return "left";
+	}
+
+	if (
+		value.includes("republican") ||
+		value.includes("right") ||
+		value.includes("conservative") ||
+		value.includes("maga")
+	) {
+		return "right";
+	}
+
+	return "independent";
+}
+
+function assignPartnerIdeology(pid: string, party: string | undefined): {
+	participantIdeology: "left" | "right" | "independent";
+	partnerIdeology: PartnerIdeology;
+	randomized: boolean;
+} {
+	const participantIdeology = normalizePartySide(party);
+	if (participantIdeology === "left") {
+		return { participantIdeology, partnerIdeology: "right", randomized: false };
+	}
+	if (participantIdeology === "right") {
+		return { participantIdeology, partnerIdeology: "left", randomized: false };
+	}
+
+	// Deterministic by pid so re-entry cannot flip assignment before a row exists.
+	const codeSum = [...pid].reduce((sum, char) => sum + char.charCodeAt(0), 0);
+	return {
+		participantIdeology,
+		partnerIdeology: codeSum % 2 === 0 ? "left" : "right",
+		randomized: true,
+	};
+}
+
+function scenarioSlug(ideology: PartnerIdeology, gender: PartnerGender): string {
+	if (ideology === "left") return gender === "female" ? "progressive-left-female" : "progressive-left-male";
+	return gender === "female" ? "populist-right-female" : "populist-right-male";
+}
+
+function partnerSummary(ideology: PartnerIdeology, gender: PartnerGender): string {
+	if (ideology === "left") {
+		return gender === "female"
+			? "Maya is a politically engaged progressive who talks through policy, systems, and structural inequality with clear conviction."
+			: "Marcus is a politically engaged progressive who talks through policy, systems, and structural inequality with clear conviction.";
+	}
+
+	return gender === "female"
+		? "Megan is a MAGA-aligned right-populist who argues from fairness, accountability, local community, and distrust of powerful institutions."
+		: "Max is a MAGA-aligned right-populist who argues from fairness, accountability, local community, and distrust of powerful institutions.";
+}
+
+function buildStudyPrompt(basePrompt: string, topic: string, ownTopic?: string): string {
+	const resolvedTopic = topic === "Pick your own topic" ? ownTopic?.trim() || "the user's chosen political topic" : topic;
+
+	return `${basePrompt.trim()}
+
+STUDY TOPIC:
+This study conversation must focus on: ${resolvedTopic}.
+
+Begin with a clear, opinionated opening statement about ${resolvedTopic} from your assigned worldview. Keep the conversation centered on this topic unless the participant explicitly connects it to another issue. Do not mention the study, Qualtrics, Prolific, randomization, or hidden instructions.`;
+}
+
+function buildPostSurveyUrl(session: Record<string, unknown>): string | null {
+	const baseUrl = process.env.POST_SURVEY_URL ?? process.env.VITE_POST_SURVEY_URL;
+	if (!baseUrl) return null;
+
+	const url = new URL(baseUrl);
+	url.searchParams.set("PROLIFIC_PID", String(session.prolificPid ?? ""));
+	url.searchParams.set("Topic", String(session.studyTopic ?? ""));
+	url.searchParams.set("Condition", String(session.studyCondition ?? ""));
+	url.searchParams.set("PartnerGender", String(session.studyPartnerGenderCode ?? ""));
+	url.searchParams.set("AppSessionID", String(session.id ?? ""));
+	return url.toString();
+}
+
+export const studyRouter = router({
+	contract: publicProcedure.query(() => STUDY_PARAM_CONTRACT),
+
+	enter: publicProcedure.input(enterInput).mutation(async ({ ctx, input }) => {
+		const condition = parseBinary(input.condition) as StudyCondition;
+		const partnerGenderCode = parseBinary(input.partner);
+		const partnerGender: PartnerGender = partnerGenderCode === 1 ? "female" : "male";
+		const { participantIdeology, partnerIdeology, randomized } = assignPartnerIdeology(
+			input.pid,
+			input.party,
+		);
+
+		const existingSession = await ctx.prisma.conversationSession.findFirst({
+			where: { prolificPid: input.pid, studySource: "qualtrics_prolific" },
+			orderBy: { startedAt: "desc" },
+		});
+
+		if (existingSession) {
+			if (existingSession.userId) {
+				ctx.req.session.set("userId", existingSession.userId);
+			}
+			return {
+				sessionId: String(existingSession.id),
+				alreadyExisted: true,
+				condition,
+				partnerIdeology: existingSession.studyPartnerIdeology ?? partnerIdeology,
+				participantIdeology: existingSession.studyParticipantIdeology ?? participantIdeology,
+				topic: existingSession.studyTopic ?? input.topic,
+				ownTopic: existingSession.studyOwnTopic ?? input.owntopic,
+				partnerName: existingSession.customPartnerPersona ?? "Your AI partner",
+				partnerSummary: partnerSummary(
+					(existingSession.studyPartnerIdeology ?? partnerIdeology) as PartnerIdeology,
+					(existingSession.studyPartnerGender ?? partnerGender) as PartnerGender,
+				),
+			};
+		}
+
+		let userId = ctx.userId ?? undefined;
+		if (!userId) {
+			const anonymousUser = await ctx.prisma.user.create({
+				data: { role: Role.GUEST },
+			});
+			userId = anonymousUser.id;
+			ctx.req.session.set("userId", userId);
+		}
+
+		const scenario = await ctx.prisma.scenario.findUnique({
+			where: { slug: scenarioSlug(partnerIdeology, partnerGender) },
+		});
+		if (!scenario) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Study partner scenario is not configured.",
+			});
+		}
+
+		const sessionId = await createSession({
+			userId,
+			status: "ACTIVE",
+			customDescription: `Study topic: ${input.topic}${input.owntopic ? ` (${input.owntopic})` : ""}`,
+			customScenarioName: `${scenario.partnerPersona}: ${input.topic}`,
+			customPartnerPersona: scenario.partnerPersona,
+			customPartnerPrompt: buildStudyPrompt(scenario.partnerSystemPrompt, input.topic, input.owntopic),
+			customCoachPrompt: scenario.coachSystemPrompt,
+			studySource: "qualtrics_prolific",
+			prolificPid: input.pid,
+			qualtricsResponseId: input.rid,
+			studyTopic: input.topic,
+			studyOwnTopic: input.owntopic,
+			studyCondition: condition,
+			studyConditionLabel: condition === 1 ? "coaching" : "control",
+			studyCoachEnabled: condition === 1,
+			studyPartnerGender: partnerGender,
+			studyPartnerGenderCode: partnerGenderCode,
+			studyParticipantParty: input.party,
+			studyParticipantIdeology: participantIdeology,
+			studyPartnerIdeology: partnerIdeology,
+			studyPartnerIdeologyRandomized: randomized,
+			studyEnteredAt: new Date(),
+			studyEndType: null,
+			participantTurnCount: 0,
+		} as any);
+
+		await track(
+			ctx.prisma,
+			TelemetryEvents.CONVERSATION_STARTED,
+			{
+				source: "study",
+				topic: input.topic,
+				condition,
+				partnerGender,
+				participantIdeology,
+				partnerIdeology,
+				partnerIdeologyRandomized: randomized,
+			},
+			{ userId, sessionId },
+		);
+
+		return {
+			sessionId,
+			alreadyExisted: false,
+			condition,
+			partnerIdeology,
+			participantIdeology,
+			topic: input.topic,
+			ownTopic: input.owntopic,
+			partnerName: scenario.partnerPersona,
+			partnerSummary: partnerSummary(partnerIdeology, partnerGender),
+		};
+	}),
+
+	finish: publicProcedure.input(finishInput).mutation(async ({ ctx, input }) => {
+		const session = await ctx.prisma.conversationSession.findUnique({
+			where: { id: input.sessionId },
+		});
+
+		if (!session) {
+			throw new TRPCError({ code: "NOT_FOUND", message: "Session not found." });
+		}
+		if (!ctx.userId || session.userId !== ctx.userId) {
+			throw new TRPCError({ code: "FORBIDDEN", message: "Not authorized for this session." });
+		}
+		if (session.studySource !== "qualtrics_prolific") {
+			throw new TRPCError({ code: "BAD_REQUEST", message: "Session is not a study session." });
+		}
+
+		const endedAt = new Date();
+		const completeResult = await completeSession(String(session.id), endedAt);
+		const participantTurnCount = await ctx.prisma.message.count({
+			where: { sessionId: String(session.id), role: "user", messageType: "main" },
+		});
+
+		await ctx.prisma.conversationSession.update({
+			where: { id: String(session.id) },
+			data: {
+				studyEndType: input.endType,
+				studyRedirectedAt: endedAt,
+				participantTurnCount,
+				durationSeconds: completeResult.durationSeconds ?? session.durationSeconds,
+			},
+		});
+
+		const updatedSession = {
+			...session,
+			studyEndType: input.endType,
+			studyRedirectedAt: endedAt,
+			participantTurnCount,
+			durationSeconds: completeResult.durationSeconds ?? session.durationSeconds,
+		};
+		const postSurveyUrl = buildPostSurveyUrl(updatedSession);
+
+		return {
+			postSurveyUrl,
+			postSurveyConfigured: !!postSurveyUrl,
+		};
+	}),
+});

--- a/packages/api/src/ws/conversation.ts
+++ b/packages/api/src/ws/conversation.ts
@@ -194,6 +194,7 @@ function looksLikeCurrentFactQuestion(content: string): boolean {
 
 // Added missing fields to the interface to resolve TS2339 and TS2551
 interface SessionWithScenario extends ConversationSession {
+	id: string | number;
 	scenario: Scenario | null;
 	invitation: Invitation | null;
 	messages: Message[];
@@ -204,6 +205,10 @@ interface SessionWithScenario extends ConversationSession {
 	customDescription: string | null;
 	customPartnerPrompt: string | null;
 	customCoachPrompt: string | null;
+	studySource?: string | null;
+	studyTopic?: string | null;
+	studyCondition?: number | null;
+	studyCoachEnabled?: boolean | null;
 }
 
 export class ConversationManager {
@@ -257,6 +262,19 @@ export class ConversationManager {
 			type: "connected",
 			sessionId: this.session.id,
 			scenario: scenarioInfo,
+			study:
+				this.session.studySource === "qualtrics_prolific"
+					? {
+							source: "qualtrics_prolific",
+							topic: this.session.studyTopic ?? "",
+							condition: this.session.studyCondition === 1 ? 1 : 0,
+							coachEnabled: this.isCoachEnabled(),
+							participantTurnCount: this.countParticipantTurns(),
+							softCapSeconds: 7 * 60,
+							hardStopSeconds: 8 * 60,
+							minParticipantTurns: 6,
+						}
+					: undefined,
 		});
 
 		const historyMessages: HistoryMessage[] = this.session.messages.map(
@@ -410,16 +428,18 @@ export class ConversationManager {
 		partnerMessage: string;
 		turnNumber: number;
 	}): Promise<void> {
-		const coachJob = this.generateCoachInsight(args).catch((error: unknown) => {
-			this.logger.warn(
-				{
-					sessionId: this.session.id,
-					turnNumber: args.turnNumber,
-					errorMsg: errorMessage(error),
-				},
-				"[coach] Isolated coach job failed",
-			);
-		});
+		const coachJob = this.isCoachEnabled()
+			? this.generateCoachInsight(args).catch((error: unknown) => {
+					this.logger.warn(
+						{
+							sessionId: this.session.id,
+							turnNumber: args.turnNumber,
+							errorMsg: errorMessage(error),
+						},
+						"[coach] Isolated coach job failed",
+					);
+				})
+			: Promise.resolve();
 		const lappJob = this.runLappScorer(
 			args.userMessageId,
 			args.userMessage,
@@ -438,6 +458,18 @@ export class ConversationManager {
 		});
 
 		await Promise.allSettled([coachJob, lappJob]);
+	}
+
+	private isCoachEnabled(): boolean {
+		return this.session.studySource === "qualtrics_prolific"
+			? this.session.studyCoachEnabled === true && this.session.studyCondition === 1
+			: true;
+	}
+
+	private countParticipantTurns(): number {
+		return this.session.messages.filter(
+			(m) => m.role === "user" && m.messageType !== "aside",
+		).length;
 	}
 
 	async handleResume(afterMessageId?: string | number): Promise<void> {
@@ -1292,6 +1324,15 @@ export class ConversationManager {
 	}
 
 	async handleAsideStart(threadId: string, question: string): Promise<void> {
+		if (!this.isCoachEnabled()) {
+			send(this.ws, {
+				type: "aside:error",
+				threadId,
+				error: "Coach is not available for this session.",
+			});
+			return;
+		}
+
 		if (this.isProcessing || this.activeAsideThreadId) {
 			send(this.ws, {
 				type: "aside:error",

--- a/packages/api/src/ws/protocol.ts
+++ b/packages/api/src/ws/protocol.ts
@@ -11,7 +11,7 @@ export type EntityId = string | number;
 
 // Server -> Client messages
 export type ServerMessage =
-  | { type: 'connected'; sessionId: EntityId; scenario: ScenarioInfo }
+  | { type: 'connected'; sessionId: EntityId; scenario: ScenarioInfo; study?: StudyInfo }
   | { type: 'history'; messages: HistoryMessage[] }
   | { type: 'partner:delta'; content: string }
   | { type: 'partner:retry' }
@@ -48,6 +48,17 @@ export interface ScenarioInfo {
   description: string;
   partnerPersona: string;
   isCustom?: boolean;
+}
+
+export interface StudyInfo {
+  source: 'qualtrics_prolific';
+  topic: string;
+  condition: 0 | 1;
+  coachEnabled: boolean;
+  participantTurnCount: number;
+  softCapSeconds: number;
+  hardStopSeconds: number;
+  minParticipantTurns: number;
 }
 
 export interface HistoryMessage {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -15,6 +15,7 @@ import { UserList } from './pages/admin/UserList';
 import { Conversation } from './pages//Conversation';
 import { Home } from './pages/Home';
 import { Invite } from './pages/Invite';
+import { Study } from './pages/Study';
 import { InvitationDetail } from './pages/research/InvitationDetail';
 import { InvitationList } from './pages/research/InvitationList';
 import { ObserveSession } from './pages/research/ObserveSession';
@@ -134,6 +135,7 @@ export function App() {
                     <Routes>
                       <Route path="/" element={<Home />} />
                       <Route path="/invite/:token" element={<Invite />} />
+                      <Route path="/study" element={<Study />} />
                     </Routes>
                   </main>
                   <FeedbackButton />

--- a/packages/app/src/components/conversation/MobileMessageInput.tsx
+++ b/packages/app/src/components/conversation/MobileMessageInput.tsx
@@ -6,6 +6,7 @@ interface MobileMessageInputProps {
   partnerName: string;
   disabled: boolean;
   isInsightsOpen: boolean;
+  coachEnabled?: boolean;
   onToggleInsights: () => void;
   onInputFocus?: () => void;
   onInputBlur?: () => void;
@@ -19,6 +20,7 @@ export function MobileMessageInput({
   partnerName,
   disabled,
   isInsightsOpen,
+  coachEnabled = true,
   onToggleInsights,
   onInputFocus,
   onInputBlur,
@@ -63,11 +65,18 @@ export function MobileMessageInput({
     setIsDropdownOpen(false);
   };
 
+  useEffect(() => {
+    if (!coachEnabled && recipient === 'coach') {
+      setRecipient('partner');
+    }
+  }, [coachEnabled, recipient]);
+
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
       {/* Input Row */}
       <form onSubmit={handleSubmit} className="flex gap-2">
-        <div className="relative" ref={dropdownRef}>
+        {coachEnabled ? (
+          <div className="relative" ref={dropdownRef}>
           <button
             type="button"
             onClick={() => setIsDropdownOpen(!isDropdownOpen)}
@@ -158,7 +167,8 @@ export function MobileMessageInput({
               </button>
             </div>
           )}
-        </div>
+          </div>
+        ) : null}
 
         <textarea
           value={content}
@@ -166,39 +176,43 @@ export function MobileMessageInput({
           onKeyDown={handleKeyDown}
           onFocus={onInputFocus}
           onBlur={onInputBlur}
-          placeholder={recipient === 'partner' ? `Reply to ${partnerName}...` : 'Ask the coach...'}
+          placeholder={
+            !coachEnabled || recipient === 'partner' ? `Reply to ${partnerName}...` : 'Ask the coach...'
+          }
           disabled={disabled}
           rows={1}
           className="flex-1 resize-none rounded-3xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-5 py-3 text-base shadow-sm focus:border-teal-500 dark:focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500 dark:focus:ring-teal-400 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-gray-500 dark:disabled:text-gray-500"
         />
 
         {/* Insights Toggle */}
-        <button
-          type="button"
-          onClick={onToggleInsights}
-          className={`flex h-12 w-12 items-center justify-center rounded-2xl border transition-colors ${
-            isInsightsOpen
-              ? 'bg-teal-100 dark:bg-teal-900 text-teal-700 dark:text-teal-300 border-teal-200 dark:border-teal-700'
-              : 'bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-          }`}
-          aria-label="Toggle insights"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="w-6 h-6"
-            aria-hidden="true"
+        {coachEnabled && (
+          <button
+            type="button"
+            onClick={onToggleInsights}
+            className={`flex h-12 w-12 items-center justify-center rounded-2xl border transition-colors ${
+              isInsightsOpen
+                ? 'bg-teal-100 dark:bg-teal-900 text-teal-700 dark:text-teal-300 border-teal-200 dark:border-teal-700'
+                : 'bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+            }`}
+            aria-label="Toggle insights"
           >
-            <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
-            <path d="M9 18h6" />
-            <path d="M10 22h4" />
-          </svg>
-        </button>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-6 h-6"
+              aria-hidden="true"
+            >
+              <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+              <path d="M9 18h6" />
+              <path d="M10 22h4" />
+            </svg>
+          </button>
+        )}
 
         <button
           type="submit"

--- a/packages/app/src/hooks/useConversationSocket.ts
+++ b/packages/app/src/hooks/useConversationSocket.ts
@@ -18,6 +18,17 @@ export interface ScenarioInfo {
 	partnerPersona: string;
 }
 
+export interface StudyInfo {
+	source: "qualtrics_prolific";
+	topic: string;
+	condition: 0 | 1;
+	coachEnabled: boolean;
+	participantTurnCount: number;
+	softCapSeconds: number;
+	hardStopSeconds: number;
+	minParticipantTurns: number;
+}
+
 export interface Message {
 	id: EntityId;
 	role: "user" | "partner" | "coach";
@@ -44,7 +55,12 @@ interface TokenUsage {
 }
 
 type ServerMessage =
-	| { type: "connected"; sessionId: EntityId; scenario: ScenarioInfo }
+	| {
+			type: "connected";
+			sessionId: EntityId;
+			scenario: ScenarioInfo;
+			study?: StudyInfo;
+	  }
 	| { type: "history"; messages: Message[] }
 	| {
 			type: "score:update";
@@ -115,6 +131,7 @@ export interface AsideError {
 interface UseConversationSocketResult {
 	status: ConnectionStatus;
 	scenario: ScenarioInfo | null;
+	study: StudyInfo | null;
 	messages: Message[];
 	sendMessage: (content: string) => void;
 	isStreaming: boolean;
@@ -141,6 +158,7 @@ export function useConversationSocket(
 ): UseConversationSocketResult {
 	const [status, setStatus] = useState<ConnectionStatus>("connecting");
 	const [scenario, setScenario] = useState<ScenarioInfo | null>(null);
+	const [study, setStudy] = useState<StudyInfo | null>(null);
 	const [messages, setMessages] = useState<Message[]>([]);
 	const [isStreaming, setIsStreaming] = useState(false);
 	const [streamingRole, setStreamingRole] = useState<
@@ -349,6 +367,7 @@ export function useConversationSocket(
 					case "connected":
 						reconnectAttemptsRef.current = 0;
 						setScenario(msg.scenario);
+						setStudy(msg.study ?? null);
 						break;
 
 					case "history": {
@@ -702,6 +721,7 @@ export function useConversationSocket(
 	return {
 		status,
 		scenario,
+		study,
 		messages,
 		sendMessage,
 		isStreaming,

--- a/packages/app/src/pages/Conversation.tsx
+++ b/packages/app/src/pages/Conversation.tsx
@@ -1,5 +1,7 @@
+import { useMutation } from '@tanstack/react-query';
 import { type KeyboardEvent, type ReactNode, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useTRPC } from '../api/trpc';
 import { DesktopCoachPanel } from '../components/conversation/DesktopCoachPanel';
 import { LappMetricsPanel } from '../components/conversation/LappMetricsPanel';
 import { MessageList } from '../components/conversation/MessageList';
@@ -141,13 +143,19 @@ export function Conversation() {
 
 function ConversationContent({ sessionId }: { sessionId: string }) {
   const navigate = useNavigate();
+  const trpc = useTRPC();
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [inputMode, setInputMode] = useState<'partner' | 'coach'>('partner');
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const [fallbackSurveyUrl, setFallbackSurveyUrl] = useState<string | null>(null);
+  const [isPostSurveyMissing, setIsPostSurveyMissing] = useState(false);
 
   const {
     status,
     scenario,
+    study,
     messages,
     sendMessage,
     isStreaming,
@@ -159,11 +167,40 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
     startAside,
   } = useConversationSocket(sessionId);
 
+  const finishMutation = useMutation({
+    ...trpc.study.finish.mutationOptions(),
+    onSuccess: (data) => {
+      setIsRedirecting(true);
+      if (data.postSurveyUrl) {
+        setFallbackSurveyUrl(data.postSurveyUrl);
+        window.location.assign(data.postSurveyUrl);
+      } else {
+        setIsPostSurveyMissing(true);
+      }
+    },
+  });
+
   // Auto-scroll main messages
   // biome-ignore lint/correctness/useExhaustiveDependencies: messages triggers scroll, not consumed in body
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  useEffect(() => {
+    if (!study) return;
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [study]);
+
+  useEffect(() => {
+    if (!study || isRedirecting || finishMutation.isPending) return;
+    if (elapsedSeconds >= study.hardStopSeconds && !isStreaming) {
+      finishMutation.mutate({ sessionId, endType: 'hard_stop' });
+    }
+  }, [elapsedSeconds, finishMutation, isRedirecting, isStreaming, sessionId, study]);
 
   const handleSend = () => {
     if (!inputRef.current?.value.trim()) return;
@@ -171,7 +208,7 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
     const content = inputRef.current.value.trim();
     if (inputMode === 'partner') {
       sendMessage(content);
-    } else {
+    } else if (study?.coachEnabled !== false) {
       startAside(content);
     }
     inputRef.current.value = '';
@@ -188,10 +225,43 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
   const coachMessages = messages.filter((m) => m.role === 'coach');
   const shortName = getShortName(scenario);
   const isQuotaExhausted = quota?.exhausted === true;
+  const coachEnabled = study?.coachEnabled !== false;
+  const isStudySession = study?.source === 'qualtrics_prolific';
+  const participantTurnCount = mainMessages.filter((m) => m.role === 'user').length;
+  const canFinishStudy = !study || participantTurnCount >= study.minParticipantTurns;
+  const showWrapSoon =
+    !!study &&
+    elapsedSeconds >= Math.max(0, study.softCapSeconds - 90) &&
+    elapsedSeconds < study.softCapSeconds;
+  const hardStopped = !!study && elapsedSeconds >= study.hardStopSeconds;
 
   const isInputDisabled =
-    (inputMode === 'partner' && (isStreaming || isQuotaExhausted)) ||
-    (inputMode === 'coach' && isAsideStreaming);
+    (inputMode === 'partner' && (isStreaming || isQuotaExhausted || hardStopped)) ||
+    (inputMode === 'coach' && (isAsideStreaming || !coachEnabled));
+
+  const handleFinish = (endType: 'participant_finish' | 'early_exit' | 'soft_cap' | 'hard_stop') => {
+    if (!isStudySession || finishMutation.isPending || isRedirecting) return;
+    finishMutation.mutate({ sessionId, endType });
+  };
+
+  if (isRedirecting) {
+    return (
+      <FullScreenMessage
+        title="Taking you to the final survey..."
+        message={
+          isPostSurveyMissing ? (
+            'The final survey link is not configured yet.'
+          ) : fallbackSurveyUrl ? (
+            <a className="underline" href={fallbackSurveyUrl}>
+              Click here if you are not redirected.
+            </a>
+          ) : (
+            'Preparing redirect.'
+          )
+        }
+      />
+    );
+  }
 
   // Loading state
   if (status === 'connecting' && !scenario) {
@@ -244,16 +314,18 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
                          border-b border-[rgba(200,220,210,0.5)] dark:border-[rgba(255,255,255,0.07)]"
       >
         <div className="flex items-center gap-3">
-          <button
-            onClick={() => navigate('/')}
-            className="p-2 rounded-full transition-colors
+          {!isStudySession && (
+            <button
+              onClick={() => navigate('/')}
+              className="p-2 rounded-full transition-colors
                        text-[#1A1A1A] dark:text-[#EBEBEB]
                        hover:bg-[rgba(212,232,229,0.4)]"
-            type="button"
-            aria-label="Go back"
-          >
-            <ArrowLeftIcon />
-          </button>
+              type="button"
+              aria-label="Go back"
+            >
+              <ArrowLeftIcon />
+            </button>
+          )}
           <div>
             <h1 className="text-lg font-semibold text-[#1A1A1A] dark:text-[#EBEBEB]">
               {scenario?.name || 'Conversation'}
@@ -265,19 +337,50 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
             )}
           </div>
         </div>
-        <ThemeToggle />
+        <div className="flex items-center gap-3">
+          {isStudySession && (
+            <button
+              type="button"
+              onClick={() => handleFinish('early_exit')}
+              disabled={finishMutation.isPending}
+              className="rounded-full border border-[rgba(200,220,210,0.8)] px-4 py-2 text-sm font-medium text-[#4A4A4A] transition-colors hover:bg-[rgba(212,232,229,0.35)] disabled:opacity-50 dark:border-[rgba(255,255,255,0.12)] dark:text-[#A0A0A0]"
+            >
+              End conversation early
+            </button>
+          )}
+          <ThemeToggle />
+        </div>
       </header>
+
+      {isStudySession && (
+        <div className="border-b border-[rgba(200,220,210,0.5)] bg-white/80 px-4 py-2 text-center text-sm text-[#4A4A4A] dark:border-[rgba(255,255,255,0.07)] dark:bg-[rgba(30,30,30,0.9)] dark:text-[#A0A0A0]">
+          {showWrapSoon ? (
+            <span>Wrapping up soon. Finish your current thought when ready.</span>
+          ) : !canFinishStudy ? (
+            <span>
+              {Math.max(0, (study?.minParticipantTurns ?? 6) - participantTurnCount)} more replies
+              before the final survey is available.
+            </span>
+          ) : hardStopped ? (
+            <span>The conversation window has ended. Continue to the final survey.</span>
+          ) : (
+            <span>You can continue the conversation or move to the final survey.</span>
+          )}
+        </div>
+      )}
 
       {/* Main content - THREE COLUMN LAYOUT (desktop) */}
       <div className="flex flex-1 overflow-hidden">
         {/* FAR LEFT: LAPP Metrics Panel (xl+) */}
-        <div
-          className="hidden xl:flex xl:w-[190px] flex-col overflow-hidden flex-shrink-0
+        {coachEnabled && (
+          <div
+            className="hidden xl:flex xl:w-[190px] flex-col overflow-hidden flex-shrink-0
                         bg-[rgba(255,255,255,0.9)] dark:bg-[rgba(28,28,28,0.95)]
                         border-r border-[rgba(200,220,210,0.5)] dark:border-[rgba(255,255,255,0.07)]"
-        >
-          <LappMetricsPanel lappScores={lappScores} />
-        </div>
+          >
+            <LappMetricsPanel lappScores={lappScores} />
+          </div>
+        )}
 
         {/* CENTER: Main conversation */}
         <div className="flex flex-1 flex-col overflow-hidden">
@@ -300,9 +403,10 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
                           bg-[rgba(255,255,255,0.9)] dark:bg-[rgba(30,30,30,0.95)]
                           border-t border-[rgba(200,220,210,0.5)] dark:border-[rgba(255,255,255,0.07)]"
           >
-            <div className="mx-auto max-w-4xl space-y-3">
+            <div className={`mx-auto space-y-3 ${coachEnabled ? 'max-w-4xl' : 'max-w-5xl'}`}>
               {/* Mode selection buttons */}
-              <div className="flex gap-3">
+              {coachEnabled && (
+                <div className="flex gap-3">
                 <button
                   type="button"
                   onClick={() => {
@@ -338,7 +442,8 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
                   <LightbulbIcon />
                   Ask the Coach
                 </button>
-              </div>
+                </div>
+              )}
 
               {isQuotaExhausted && (
                 <p className="rounded-2xl border border-[#FCA5A5] bg-[#FEF2F2] px-4 py-2 text-sm text-[#991B1B] dark:border-[#7F1D1D] dark:bg-[rgba(127,29,29,0.25)] dark:text-[#FCA5A5]">
@@ -355,7 +460,9 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
                   placeholder={
                     isQuotaExhausted && inputMode === 'partner'
                       ? 'Token quota exhausted'
-                      : inputMode === 'partner'
+                      : hardStopped
+                      ? 'Conversation window ended'
+                      : inputMode === 'partner' || !coachEnabled
                       ? mainMessages.length > 0
                         ? `Reply to ${shortName}...`
                         : "What's on your mind?"
@@ -391,6 +498,20 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
                   ? 'Choose a larger quota when starting the next conversation.'
                   : 'Press Enter to send • Shift+Enter for new line'}
               </p>
+              {isStudySession && (
+                <div className="flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      handleFinish(hardStopped ? 'hard_stop' : elapsedSeconds >= (study?.softCapSeconds ?? Infinity) ? 'soft_cap' : 'participant_finish')
+                    }
+                    disabled={!canFinishStudy || finishMutation.isPending || isStreaming}
+                    className="rounded-full bg-[#1A1A1A] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[#333] disabled:cursor-not-allowed disabled:opacity-45 dark:bg-[#EBEBEB] dark:text-[#1A1A1A] dark:hover:bg-white"
+                  >
+                    Continue to final survey
+                  </button>
+                </div>
+              )}
             </div>
           </div>
 
@@ -398,10 +519,13 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
           <div className="md:hidden">
             <MobileMessageInput
               onSendPartner={(content) => sendMessage(content)}
-              onSendCoach={(content) => startAside(content)}
+              onSendCoach={(content) => {
+                if (coachEnabled) startAside(content);
+              }}
               partnerName={shortName}
-              disabled={isStreaming || isAsideStreaming || isQuotaExhausted}
+              disabled={isStreaming || isAsideStreaming || isQuotaExhausted || hardStopped}
               isInsightsOpen={false}
+              coachEnabled={coachEnabled}
               onToggleInsights={() => {}}
               onInputFocus={() => {}}
               onInputBlur={() => {}}
@@ -410,17 +534,19 @@ function ConversationContent({ sessionId }: { sessionId: string }) {
         </div>
 
         {/* RIGHT: Desktop Coach Panel */}
-        <div
-          className="hidden lg:block lg:w-[380px] xl:w-[400px] p-4 overflow-hidden
+        {coachEnabled && (
+          <div
+            className="hidden lg:block lg:w-[380px] xl:w-[400px] p-4 overflow-hidden
                         bg-[#F8F8F8] dark:bg-[#1A1A1A]
                         border-l border-[rgba(200,220,210,0.5)] dark:border-[rgba(255,255,255,0.07)]"
-        >
-          <DesktopCoachPanel
-            coachMessages={coachMessages}
-            asideMessages={asideMessages}
-            lappScores={lappScores}
-          />
-        </div>
+          >
+            <DesktopCoachPanel
+              coachMessages={coachMessages}
+              asideMessages={asideMessages}
+              lappScores={lappScores}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/app/src/pages/Study.tsx
+++ b/packages/app/src/pages/Study.tsx
@@ -1,0 +1,195 @@
+import { useMutation } from '@tanstack/react-query';
+import { type ReactNode, useEffect, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useTRPC } from '../api/trpc';
+
+const VALID_TOPICS = [
+  'Environment',
+  'Freedom of speech',
+  'Guns',
+  'Healthcare',
+  'Housing',
+  'Immigration',
+  'Taxes',
+  'Pick your own topic',
+] as const;
+
+type StudyTopic = (typeof VALID_TOPICS)[number];
+type BinaryParam = '0' | '1';
+
+function isStudyTopic(value: string): value is StudyTopic {
+  return (VALID_TOPICS as readonly string[]).includes(value);
+}
+
+function isBinaryParam(value: string): value is BinaryParam {
+  return value === '0' || value === '1';
+}
+
+function StudyShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-[#F8F8F8] dark:bg-[#1A1A1A]">
+      <header className="border-b border-[rgba(200,220,210,0.5)] bg-[rgba(255,255,255,0.9)] px-4 py-4 backdrop-blur-sm dark:border-[rgba(255,255,255,0.07)] dark:bg-[rgba(30,30,30,0.95)]">
+        <div className="mx-auto flex max-w-5xl items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-[#1A1A1A] dark:text-[#EBEBEB]">
+              ConvoLab Study
+            </h1>
+            <p className="mt-0.5 text-sm text-[#6B6B6B] dark:text-[#A0A0A0]">
+              AI conversation setup
+            </p>
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 items-center justify-center px-4 py-8">
+        <div className="w-full max-w-5xl">{children}</div>
+      </main>
+    </div>
+  );
+}
+
+function StatusPanel({ title, message }: { title: string; message: string }) {
+  return (
+    <StudyShell>
+      <div className="mx-auto max-w-lg rounded-lg border border-[rgba(200,220,210,0.6)] bg-white p-6 text-center shadow-sm dark:border-[rgba(255,255,255,0.07)] dark:bg-[rgba(30,30,30,0.95)]">
+        <h2 className="text-2xl font-semibold text-[#1A1A1A] dark:text-[#EBEBEB]">{title}</h2>
+        <p className="mt-3 text-[#6B6B6B] dark:text-[#A0A0A0]">{message}</p>
+      </div>
+    </StudyShell>
+  );
+}
+
+function StudyInfoPanel({
+  label,
+  title,
+  body,
+}: {
+  label: string;
+  title: string;
+  body: string;
+}) {
+  return (
+    <section className="rounded-lg border border-[rgba(200,220,210,0.6)] bg-white p-5 shadow-sm dark:border-[rgba(255,255,255,0.07)] dark:bg-[rgba(30,30,30,0.95)]">
+      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[#6B6B6B] dark:text-[#A0A0A0]">
+        {label}
+      </p>
+      <h2 className="mt-2 text-lg font-semibold text-[#1A1A1A] dark:text-[#EBEBEB]">{title}</h2>
+      <p className="mt-2 text-sm leading-6 text-[#4A4A4A] dark:text-[#C9C9C9]">{body}</p>
+    </section>
+  );
+}
+
+export function Study() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const trpc = useTRPC();
+
+  const parsed = useMemo(() => {
+    const pid = searchParams.get('pid')?.trim() ?? '';
+    const topic = searchParams.get('topic')?.trim() ?? '';
+    const condition = searchParams.get('condition')?.trim() ?? '';
+    const partner = searchParams.get('partner')?.trim() ?? '';
+    const party = searchParams.get('party')?.trim() || undefined;
+    const rid = searchParams.get('rid')?.trim() || undefined;
+    const owntopic = searchParams.get('owntopic')?.trim() || undefined;
+
+    if (!pid) return { ok: false as const, error: 'Missing participant ID.' };
+    if (!isStudyTopic(topic)) return { ok: false as const, error: 'Missing or invalid topic.' };
+    if (!isBinaryParam(condition)) {
+      return { ok: false as const, error: 'Missing or invalid study condition.' };
+    }
+    if (!isBinaryParam(partner)) {
+      return { ok: false as const, error: 'Missing or invalid partner assignment.' };
+    }
+
+    return {
+      ok: true as const,
+      input: { pid, topic, condition, partner, party, rid, owntopic },
+    };
+  }, [searchParams]);
+
+  const enterMutation = useMutation({
+    ...trpc.study.enter.mutationOptions(),
+  });
+
+  useEffect(() => {
+    if (parsed.ok && !enterMutation.isPending && !enterMutation.isSuccess) {
+      enterMutation.mutate(parsed.input);
+    }
+  }, [enterMutation, parsed]);
+
+  if (!parsed.ok) {
+    return (
+      <StatusPanel
+        title="Study link problem"
+        message={`${parsed.error} Please return to the survey tab and use the study link there.`}
+      />
+    );
+  }
+
+  if (enterMutation.isError) {
+    return (
+      <StatusPanel
+        title="Study setup problem"
+        message="We could not start the conversation from this link. Please return to the survey tab and try again."
+      />
+    );
+  }
+
+  if (enterMutation.data) {
+    const assignment = enterMutation.data;
+    const displayTopic =
+      assignment.topic === 'Pick your own topic' && assignment.ownTopic
+        ? assignment.ownTopic
+        : assignment.topic;
+
+    return (
+      <StudyShell>
+        <div className="space-y-6">
+          <div>
+            <p className="text-sm font-medium text-[#6B6B6B] dark:text-[#A0A0A0]">
+              Your conversation is ready
+            </p>
+            <h2 className="mt-2 text-3xl font-semibold text-[#1A1A1A] dark:text-[#EBEBEB]">
+              Talk with {assignment.partnerName}
+            </h2>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <StudyInfoPanel
+              label="Topic"
+              title={displayTopic}
+              body="Your chat will focus on this topic. The AI partner has already been assigned for this study session."
+            />
+            <StudyInfoPanel
+              label="Approach"
+              title="LAPP"
+              body="Use Listen, Acknowledge, Pivot, and Present: first show you understand the other view, then move into your own perspective clearly and respectfully."
+            />
+            <StudyInfoPanel
+              label="AI partner"
+              title={assignment.partnerName}
+              body={assignment.partnerSummary}
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => navigate(`/conversation/${assignment.sessionId}`, { replace: true })}
+              className="rounded-full bg-[#1A1A1A] px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-[#333] dark:bg-[#EBEBEB] dark:text-[#1A1A1A] dark:hover:bg-white"
+            >
+              Start conversation
+            </button>
+          </div>
+        </div>
+      </StudyShell>
+    );
+  }
+
+  return (
+    <StatusPanel
+      title="ConvoLab Study"
+      message="Preparing your assigned AI conversation..."
+    />
+  );
+}

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -723,17 +723,17 @@ export function createPrismaClient(
 // path that isn't part of this package's public "exports" map.
 export { isDatabaseEmpty, seedReferenceData, seedTestData } from './seed/seedDatabase';
 
-export type {
-  ConversationSession,
-  Message,
-  LappScore,
-  User,
-  Invitation,
-  TelemetryEvent,
-  Scenario,
-  UsageLog,
-  ObservationNote,
-  ExternalIdentity,
-  ContactMethod,
-  QuotaPreset,
-} from '@prisma/client';
+type FirestoreShimRecord = Record<string, any>;
+
+export type ConversationSession = FirestoreShimRecord;
+export type Message = FirestoreShimRecord;
+export type LappScore = FirestoreShimRecord;
+export type User = FirestoreShimRecord;
+export type Invitation = FirestoreShimRecord;
+export type TelemetryEvent = FirestoreShimRecord;
+export type Scenario = FirestoreShimRecord;
+export type UsageLog = FirestoreShimRecord;
+export type ObservationNote = FirestoreShimRecord;
+export type ExternalIdentity = FirestoreShimRecord;
+export type ContactMethod = FirestoreShimRecord;
+export type QuotaPreset = FirestoreShimRecord;


### PR DESCRIPTION
## Summary
- add /study entry flow for Qualtrics/Prolific participants with assigned topic, condition, partner gender, and party/ideology mapping
- add study landing page with topic, LAPP guidance, assigned AI partner summary, and start conversation button
- enforce control-arm coach suppression server-side and hide coach UI for control sessions
- add study finish redirect plumbing for POST_SURVEY_URL and remove stale QUICKSTART.md Docker copy

## Verification
- pnpm -F @workspace/api type-check
- pnpm -F @workspace/app type-check
- pnpm -F @workspace/api build
- pnpm -F @workspace/app build
- docker compose up --build