### PR TITLE
Add fail-closed Firestore test guard

### DIFF
--- a/packages/api/src/__tests__/firestoreProductionGuard.test.ts
+++ b/packages/api/src/__tests__/firestoreProductionGuard.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertSafeFirestoreTestTarget,
+  PROD_FIRESTORE_PROJECT_ID,
+} from './firestoreProductionGuard.js';
+
+describe('assertSafeFirestoreTestTarget', () => {
+  it.each([
+    undefined,
+    '',
+  ])('refuses the production project with emulator host %s', (emulatorHost) => {
+    expect(() =>
+      assertSafeFirestoreTestTarget({
+        FIRESTORE_PROJECT_ID: PROD_FIRESTORE_PROJECT_ID,
+        FIRESTORE_EMULATOR_HOST: emulatorHost,
+      })
+    ).toThrow('Refusing to run tests against production Firestore. Set FIRESTORE_EMULATOR_HOST.');
+  });
+
+  it('allows the production project when an emulator host is configured', () => {
+    expect(() =>
+      assertSafeFirestoreTestTarget({
+        FIRESTORE_PROJECT_ID: PROD_FIRESTORE_PROJECT_ID,
+        FIRESTORE_EMULATOR_HOST: '127.0.0.1:8080',
+      })
+    ).not.toThrow();
+  });
+
+  it('allows a non-production project without an emulator host', () => {
+    expect(() =>
+      assertSafeFirestoreTestTarget({
+        FIRESTORE_PROJECT_ID: 'convolab-test',
+        FIRESTORE_EMULATOR_HOST: undefined,
+      })
+    ).not.toThrow();
+  });
+
+  it('preserves existing behavior when the project ID is missing', () => {
+    expect(() =>
+      assertSafeFirestoreTestTarget({
+        FIRESTORE_PROJECT_ID: undefined,
+        FIRESTORE_EMULATOR_HOST: undefined,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/api/src/__tests__/firestoreProductionGuard.ts
+++ b/packages/api/src/__tests__/firestoreProductionGuard.ts
@@ -1,0 +1,14 @@
+export const PROD_FIRESTORE_PROJECT_ID = 'convolab-490517';
+
+export function assertSafeFirestoreTestTarget(
+  env: Pick<NodeJS.ProcessEnv, 'FIRESTORE_PROJECT_ID' | 'FIRESTORE_EMULATOR_HOST'> = process.env
+): void {
+  const projectId = env.FIRESTORE_PROJECT_ID;
+  const emulatorHost = env.FIRESTORE_EMULATOR_HOST;
+
+  if (projectId === PROD_FIRESTORE_PROJECT_ID && !emulatorHost) {
+    throw new Error(
+      'Refusing to run tests against production Firestore. Set FIRESTORE_EMULATOR_HOST.'
+    );
+  }
+}

--- a/packages/api/src/__tests__/setup.ts
+++ b/packages/api/src/__tests__/setup.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
 import dotenv from "dotenv";
+import { assertSafeFirestoreTestTarget } from './firestoreProductionGuard.js';
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
 });
 
+assertSafeFirestoreTestTarget();
 
 import { afterAll, beforeAll, beforeEach } from 'vitest';
 

--- a/packages/api/vitest.atomic.config.ts
+++ b/packages/api/vitest.atomic.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    setupFiles: ['./src/__tests__/setup.ts'],
     include: [
       'src/__tests__/firestoreProductionGuard.test.ts',
       'src/data/atomic.test.ts',

--- a/packages/api/vitest.atomic.config.ts
+++ b/packages/api/vitest.atomic.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/data/atomic.test.ts', 'src/ws/conversation.atomic.test.ts'],
+    include: [
+      'src/__tests__/firestoreProductionGuard.test.ts',
+      'src/data/atomic.test.ts',
+      'src/ws/conversation.atomic.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- prevents tests from running against production Firestore unless FIRESTORE_EMULATOR_HOST is configured
- fails immediately before Firestore initialization or test cleanup
- adds focused coverage for production, emulator, non-production, and missing-project configurations

## Safety behavior
- production project: convolab-490517
- production + no emulator => refuses to run
- production + emulator => allowed
- non-production => allowed

## Testing
- guard tests: 5 passed
- Firestore atomicity tests: 8 passed
- git diff --check: passed
- no production Firestore or Cloud SQL connection was attempted